### PR TITLE
Bugfix: When filter blob on timestamp, ticks should be equal or bigge…

### DIFF
--- a/src/Akka.Persistence.Azure/Snapshot/AzureBlobSnapshotStore.cs
+++ b/src/Akka.Persistence.Azure/Snapshot/AzureBlobSnapshotStore.cs
@@ -234,7 +234,7 @@ namespace Akka.Persistence.Azure.Snapshot
         {
             var ticks = FetchBlobTimestamp(x);
             return ticks <= criteria.MaxTimeStamp.Ticks &&
-                   (!criteria.MinTimestamp.HasValue || criteria.MinTimestamp.Value.Ticks >= ticks);
+                   (!criteria.MinTimestamp.HasValue || ticks >= criteria.MinTimestamp.Value.Ticks);
         }
 
         private static long FetchBlobTimestamp(CloudBlob x)


### PR DESCRIPTION
…r than criteria's min timestamp