### PR TITLE
Update to latest releases

### DIFF
--- a/src/Akka.Persistence.Azure.TestHelpers/Akka.Persistence.Azure.TestHelpers.csproj
+++ b/src/Akka.Persistence.Azure.TestHelpers/Akka.Persistence.Azure.TestHelpers.csproj
@@ -5,7 +5,7 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Docker.DotNet" Version="3.125.2" />
+    <PackageReference Include="Docker.DotNet" Version="3.125.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Akka.Persistence.Azure.Tests/Akka.Persistence.Azure.Tests.csproj
+++ b/src/Akka.Persistence.Azure.Tests/Akka.Persistence.Azure.Tests.csproj
@@ -6,11 +6,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Akka.Persistence.TCK" Version="$(AkkaVersion)" />
+    <PackageReference Include="Akka.Persistence.TCK" Version="1.4.11" />
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/Akka.Persistence.Azure/Akka.Persistence.Azure.csproj
+++ b/src/Akka.Persistence.Azure/Akka.Persistence.Azure.csproj
@@ -13,7 +13,7 @@
 
 
   <ItemGroup>
-    <PackageReference Include="Akka.Persistence.Query" Version="$(AkkaVersion)" />
+    <PackageReference Include="Akka.Persistence.Query" Version="1.4.11" />
     <PackageReference Include="WindowsAzure.Storage" Version="9.3.3" />
   </ItemGroup>
 


### PR DESCRIPTION
We have Akka.Persistence.Azure plugin stuck on older releases of Akka.NET - this is because of some changes we made to the Akka.Persistence.TCK in Akka.NET v1.4.10.