### PR TITLE
[Snapshot] Cosmos SQL API

### DIFF
--- a/src/Akka.Persistence.Azure.TestHelpers/AzureEmulatorFixture.cs
+++ b/src/Akka.Persistence.Azure.TestHelpers/AzureEmulatorFixture.cs
@@ -17,7 +17,7 @@ namespace Akka.Persistence.Azure.TestHelpers
     ///     Integration testing fixture using the Windows Azure Storage Emulator
     ///     Docker image provided by Microsoft: https://hub.docker.com/r/microsoft/azure-storage-emulator/
     /// </summary>
-    public class WindowsAzureStorageEmulatorFixture : IAsyncFixture
+    public class AzureEmulatorFixture : IAsyncFixture
     {
         private const string AzureStorageImageName = "microsoft/azure-storage-emulator";
         private readonly string _azureStorageContainerName = $"azurestorage-{Guid.NewGuid():N}";

--- a/src/Akka.Persistence.Azure.TestHelpers/AzureEmulatorFixture.cs
+++ b/src/Akka.Persistence.Azure.TestHelpers/AzureEmulatorFixture.cs
@@ -116,8 +116,7 @@ namespace Akka.Persistence.Azure.TestHelpers
         public static string GenerateConnStr(string ip = "127.0.0.1", int blobport = 10000, int queueport = 10001,
             int tableport = 10002)
         {
-            return
-                $"DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://{ip}:{blobport}/devstoreaccount1;TableEndpoint=http://{ip}:{tableport}/devstoreaccount1;QueueEndpoint=http://{ip}:{queueport}/devstoreaccount1;";
+            return $"AccountEndpoint=https://localhost:8081/;AccountKey=C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==";
         }
     }
 }

--- a/src/Akka.Persistence.Azure.TestHelpers/DbUtils.cs
+++ b/src/Akka.Persistence.Azure.TestHelpers/DbUtils.cs
@@ -1,6 +1,6 @@
 using System.Threading.Tasks;
 using Akka.Actor;
-using Microsoft.WindowsAzure.Storage;
+using Microsoft.Azure.Cosmos.Table;
 
 namespace Akka.Persistence.Azure.TestHelpers
 {

--- a/src/Akka.Persistence.Azure.Tests.Performance/AzureJournalPerfSpecs.cs
+++ b/src/Akka.Persistence.Azure.Tests.Performance/AzureJournalPerfSpecs.cs
@@ -38,7 +38,7 @@ namespace Akka.Persistence.Azure.Tests.Performance
             if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("AZURE_CONNECTION_STR")))
                 return JournalConfig(Environment.GetEnvironmentVariable("AZURE_CONNECTION_STR"));
 
-            return JournalConfig(WindowsAzureStorageEmulatorFixture.GenerateConnStr());
+            return JournalConfig(AzureEmulatorFixture.GenerateConnStr());
         }
 
         public static Config JournalConfig(string connectionString)

--- a/src/Akka.Persistence.Azure.Tests/AzureBlobSnapshotStoreSerializationSpec.cs
+++ b/src/Akka.Persistence.Azure.Tests/AzureBlobSnapshotStoreSerializationSpec.cs
@@ -28,7 +28,7 @@ namespace Akka.Persistence.Azure.Tests
             if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("AZURE_CONNECTION_STR")))
                 return AzureStorageConfigHelper.AzureConfig(Environment.GetEnvironmentVariable("AZURE_CONNECTION_STR"));
 
-            return AzureStorageConfigHelper.AzureConfig(WindowsAzureStorageEmulatorFixture.GenerateConnStr());
+            return AzureStorageConfigHelper.AzureConfig(AzureEmulatorFixture.GenerateConnStr());
         }
     }
 }

--- a/src/Akka.Persistence.Azure.Tests/AzureBlobSnapshotStoreSpec.cs
+++ b/src/Akka.Persistence.Azure.Tests/AzureBlobSnapshotStoreSpec.cs
@@ -29,7 +29,7 @@ namespace Akka.Persistence.Azure.Tests
             if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("AZURE_CONNECTION_STR")))
                 return AzureConfig(Environment.GetEnvironmentVariable("AZURE_CONNECTION_STR"));
 
-            return AzureConfig(WindowsAzureStorageEmulatorFixture.GenerateConnStr());
+            return AzureConfig(AzureEmulatorFixture.GenerateConnStr());
         }
     }
 }

--- a/src/Akka.Persistence.Azure.Tests/AzureTableJournalEscapePersistentIdSpec.cs
+++ b/src/Akka.Persistence.Azure.Tests/AzureTableJournalEscapePersistentIdSpec.cs
@@ -12,7 +12,7 @@ using static Akka.Persistence.Azure.Tests.Helper.AzureStorageConfigHelper;
 
 namespace Akka.Persistence.Azure.Tests
 {
-    public class AzureTableJournalEscapePersistentIdSpec : AzureTableJournalSpec, IClassFixture<WindowsAzureStorageEmulatorFixture>
+    public class AzureTableJournalEscapePersistentIdSpec : AzureTableJournalSpec, IClassFixture<AzureEmulatorFixture>
     {
         public AzureTableJournalEscapePersistentIdSpec(ITestOutputHelper output) : base(output)
         {

--- a/src/Akka.Persistence.Azure.Tests/AzureTableJournalSerializationSpec.cs
+++ b/src/Akka.Persistence.Azure.Tests/AzureTableJournalSerializationSpec.cs
@@ -37,7 +37,7 @@ namespace Akka.Persistence.Azure.Tests
             var azureConfig =
                 !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("AZURE_CONNECTION_STR"))
                     ? AzureStorageConfigHelper.AzureConfig(Environment.GetEnvironmentVariable("AZURE_CONNECTION_STR"))
-                    : AzureStorageConfigHelper.AzureConfig(WindowsAzureStorageEmulatorFixture.GenerateConnStr());
+                    : AzureStorageConfigHelper.AzureConfig(AzureEmulatorFixture.GenerateConnStr());
 
             TableName = azureConfig.GetString("akka.persistence.journal.azure-table.table-name");
 

--- a/src/Akka.Persistence.Azure.Tests/AzureTableJournalSpec.cs
+++ b/src/Akka.Persistence.Azure.Tests/AzureTableJournalSpec.cs
@@ -36,7 +36,7 @@ namespace Akka.Persistence.Azure.Tests
             var azureConfig =
                 !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("AZURE_CONNECTION_STR"))
                     ? AzureConfig(Environment.GetEnvironmentVariable("AZURE_CONNECTION_STR"))
-                    : AzureConfig(WindowsAzureStorageEmulatorFixture.GenerateConnStr());
+                    : AzureConfig(AzureEmulatorFixture.GenerateConnStr());
 
             TableName = azureConfig.GetString("akka.persistence.journal.azure-table.table-name");
 

--- a/src/Akka.Persistence.Azure.Tests/Query/AzureTableCurrentEventsByPersistenceIdSpec.cs
+++ b/src/Akka.Persistence.Azure.Tests/Query/AzureTableCurrentEventsByPersistenceIdSpec.cs
@@ -33,7 +33,7 @@ namespace Akka.Persistence.Azure.Tests.Query
             var azureConfig =
                 !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("AZURE_CONNECTION_STR"))
                     ? AzureStorageConfigHelper.AzureConfig(Environment.GetEnvironmentVariable("AZURE_CONNECTION_STR"))
-                    : AzureStorageConfigHelper.AzureConfig(WindowsAzureStorageEmulatorFixture.GenerateConnStr());
+                    : AzureStorageConfigHelper.AzureConfig(AzureEmulatorFixture.GenerateConnStr());
 
             TableName = azureConfig.GetString("akka.persistence.journal.azure-table.table-name");
 

--- a/src/Akka.Persistence.Azure.Tests/Query/AzureTableCurrentEventsByTagSpec.cs
+++ b/src/Akka.Persistence.Azure.Tests/Query/AzureTableCurrentEventsByTagSpec.cs
@@ -39,7 +39,7 @@ namespace Akka.Persistence.Azure.Tests.Query
             var azureConfig =
                 !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("AZURE_CONNECTION_STR"))
                     ? AzureStorageConfigHelper.AzureConfig(Environment.GetEnvironmentVariable("AZURE_CONNECTION_STR"))
-                    : AzureStorageConfigHelper.AzureConfig(WindowsAzureStorageEmulatorFixture.GenerateConnStr());
+                    : AzureStorageConfigHelper.AzureConfig(AzureEmulatorFixture.GenerateConnStr());
 
             TableName = azureConfig.GetString("akka.persistence.journal.azure-table.table-name");
 

--- a/src/Akka.Persistence.Azure.Tests/Query/AzureTableCurrentPersistenceIdsSpec.cs
+++ b/src/Akka.Persistence.Azure.Tests/Query/AzureTableCurrentPersistenceIdsSpec.cs
@@ -41,7 +41,7 @@ namespace Akka.Persistence.Azure.Tests.Query
             var azureConfig =
                 !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("AZURE_CONNECTION_STR"))
                     ? AzureStorageConfigHelper.AzureConfig(Environment.GetEnvironmentVariable("AZURE_CONNECTION_STR"))
-                    : AzureStorageConfigHelper.AzureConfig(WindowsAzureStorageEmulatorFixture.GenerateConnStr());
+                    : AzureStorageConfigHelper.AzureConfig(AzureEmulatorFixture.GenerateConnStr());
 
             TableName = azureConfig.GetString("akka.persistence.journal.azure-table.table-name");
 

--- a/src/Akka.Persistence.Azure.Tests/Query/AzureTableEventsByPersistenceIdSpec.cs
+++ b/src/Akka.Persistence.Azure.Tests/Query/AzureTableEventsByPersistenceIdSpec.cs
@@ -33,7 +33,7 @@ namespace Akka.Persistence.Azure.Tests.Query
             var azureConfig =
                 !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("AZURE_CONNECTION_STR"))
                     ? AzureStorageConfigHelper.AzureConfig(Environment.GetEnvironmentVariable("AZURE_CONNECTION_STR"))
-                    : AzureStorageConfigHelper.AzureConfig(WindowsAzureStorageEmulatorFixture.GenerateConnStr());
+                    : AzureStorageConfigHelper.AzureConfig(AzureEmulatorFixture.GenerateConnStr());
 
             TableName = azureConfig.GetString("akka.persistence.journal.azure-table.table-name");
 

--- a/src/Akka.Persistence.Azure.Tests/Query/AzureTableEventsByTagSpec.cs
+++ b/src/Akka.Persistence.Azure.Tests/Query/AzureTableEventsByTagSpec.cs
@@ -39,7 +39,7 @@ namespace Akka.Persistence.Azure.Tests.Query
             var azureConfig =
                 !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("AZURE_CONNECTION_STR"))
                     ? AzureStorageConfigHelper.AzureConfig(Environment.GetEnvironmentVariable("AZURE_CONNECTION_STR"))
-                    : AzureStorageConfigHelper.AzureConfig(WindowsAzureStorageEmulatorFixture.GenerateConnStr());
+                    : AzureStorageConfigHelper.AzureConfig(AzureEmulatorFixture.GenerateConnStr());
 
             TableName = azureConfig.GetString("akka.persistence.journal.azure-table.table-name");
 

--- a/src/Akka.Persistence.Azure.Tests/Query/AzureTablePersistenceIdsSpec.cs
+++ b/src/Akka.Persistence.Azure.Tests/Query/AzureTablePersistenceIdsSpec.cs
@@ -31,7 +31,7 @@ namespace Akka.Persistence.Azure.Tests.Query
             var azureConfig =
                 !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("AZURE_CONNECTION_STR"))
                     ? AzureConfig(Environment.GetEnvironmentVariable("AZURE_CONNECTION_STR"))
-                    : AzureConfig(WindowsAzureStorageEmulatorFixture.GenerateConnStr());
+                    : AzureConfig(AzureEmulatorFixture.GenerateConnStr());
 
             TableName = azureConfig.GetString("akka.persistence.journal.azure-table.table-name");
 

--- a/src/Akka.Persistence.Azure.Tests/Query/AzureTableQueryEdgeCaseSpecs.cs
+++ b/src/Akka.Persistence.Azure.Tests/Query/AzureTableQueryEdgeCaseSpecs.cs
@@ -180,7 +180,7 @@ namespace Akka.Persistence.Azure.Tests.Query
             var azureConfig =
                 !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("AZURE_CONNECTION_STR"))
                     ? AzureStorageConfigHelper.AzureConfig(Environment.GetEnvironmentVariable("AZURE_CONNECTION_STR"))
-                    : AzureStorageConfigHelper.AzureConfig(WindowsAzureStorageEmulatorFixture.GenerateConnStr());
+                    : AzureStorageConfigHelper.AzureConfig(AzureEmulatorFixture.GenerateConnStr());
 
             TableName = azureConfig.GetString("akka.persistence.journal.azure-table.table-name");
 

--- a/src/Akka.Persistence.Azure.Tests/SerializerHelperSpecs.cs
+++ b/src/Akka.Persistence.Azure.Tests/SerializerHelperSpecs.cs
@@ -28,7 +28,7 @@ namespace Akka.Persistence.Azure.Tests
             var azureConfig =
                 !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("AZURE_CONNECTION_STR"))
                     ? AzureStorageConfigHelper.AzureConfig(Environment.GetEnvironmentVariable("AZURE_CONNECTION_STR"))
-                    : AzureStorageConfigHelper.AzureConfig(WindowsAzureStorageEmulatorFixture.GenerateConnStr());
+                    : AzureStorageConfigHelper.AzureConfig(AzureEmulatorFixture.GenerateConnStr());
 
             return azureConfig;
         }

--- a/src/Akka.Persistence.Azure/Akka.Persistence.Azure.csproj
+++ b/src/Akka.Persistence.Azure/Akka.Persistence.Azure.csproj
@@ -14,7 +14,8 @@
 
   <ItemGroup>
     <PackageReference Include="Akka.Persistence.Query" Version="$(AkkaVersion)" />
-    <PackageReference Include="WindowsAzure.Storage" Version="9.3.3" />
+    <PackageReference Include="Microsoft.Azure.Cosmos.Table" Version="1.0.8" />
+    <PackageReference Include="Microsoft.Azure.Storage.Blob" Version="11.2.2" />
   </ItemGroup>
 
 </Project>

--- a/src/Akka.Persistence.Azure/Akka.Persistence.Azure.csproj
+++ b/src/Akka.Persistence.Azure/Akka.Persistence.Azure.csproj
@@ -14,6 +14,7 @@
 
   <ItemGroup>
     <PackageReference Include="Akka.Persistence.Query" Version="$(AkkaVersion)" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.15.0" />
     <PackageReference Include="Microsoft.Azure.Cosmos.Table" Version="1.0.8" />
     <PackageReference Include="Microsoft.Azure.Storage.Blob" Version="11.2.2" />
   </ItemGroup>

--- a/src/Akka.Persistence.Azure/Journal/AzureTableStorageJournal.cs
+++ b/src/Akka.Persistence.Azure/Journal/AzureTableStorageJournal.cs
@@ -21,6 +21,7 @@ using Akka.Configuration;
 using Debug = System.Diagnostics.Debug;
 using Microsoft.Azure.Cosmos.Table;
 
+//https://medium.com/@willvelida/getting-started-with-the-table-api-in-azure-cosmos-db-1509fd52e46b
 namespace Akka.Persistence.Azure.Journal
 {
     /// <inheritdoc />
@@ -90,7 +91,6 @@ namespace Akka.Persistence.Azure.Journal
             var sequenceNumberQuery = GenerateHighestSequenceNumberQuery(persistenceId);
             TableQuerySegment<HighestSequenceNrEntry> result = null;
             long seqNo = 0L;
-
             do
             {
                 result = await Table.ExecuteQuerySegmentedAsync(sequenceNumberQuery, result?.ContinuationToken);

--- a/src/Akka.Persistence.Azure/Journal/AzureTableStorageJournal.cs
+++ b/src/Akka.Persistence.Azure/Journal/AzureTableStorageJournal.cs
@@ -11,8 +11,6 @@ using Akka.Persistence.Azure.TableEntities;
 using Akka.Persistence.Azure.Util;
 using Akka.Persistence.Journal;
 using Akka.Util.Internal;
-using Microsoft.WindowsAzure.Storage;
-using Microsoft.WindowsAzure.Storage.Table;
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
@@ -21,6 +19,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Akka.Configuration;
 using Debug = System.Diagnostics.Debug;
+using Microsoft.Azure.Cosmos.Table;
 
 namespace Akka.Persistence.Azure.Journal
 {

--- a/src/Akka.Persistence.Azure/Journal/AzureTableStorageJournal.cs
+++ b/src/Akka.Persistence.Azure/Journal/AzureTableStorageJournal.cs
@@ -707,7 +707,7 @@ namespace Akka.Persistence.Azure.Journal
         {
             var query = GenerateAllPersistenceIdsQuery();
 
-            TableQuerySegment result = null;
+            TableQuerySegment<DynamicTableEntity> result = null;
 
             var returnValue = ImmutableList<string>.Empty;
 

--- a/src/Akka.Persistence.Azure/Journal/AzureTableStorageJournalSettings.cs
+++ b/src/Akka.Persistence.Azure/Journal/AzureTableStorageJournalSettings.cs
@@ -7,7 +7,7 @@
 using System;
 using System.Linq;
 using Akka.Configuration;
-using Microsoft.WindowsAzure.Storage;
+using Microsoft.Azure.Cosmos.Table;
 
 namespace Akka.Persistence.Azure.Journal
 {

--- a/src/Akka.Persistence.Azure/Journal/HighestSequenceNrEntry.cs
+++ b/src/Akka.Persistence.Azure/Journal/HighestSequenceNrEntry.cs
@@ -1,8 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text;
-using Microsoft.WindowsAzure.Storage;
-using Microsoft.WindowsAzure.Storage.Table;
+using Microsoft.Azure.Cosmos.Table;
 
 namespace Akka.Persistence.Azure.Journal
 {

--- a/src/Akka.Persistence.Azure/Query/AzureTableStorageReadJournal.cs
+++ b/src/Akka.Persistence.Azure/Query/AzureTableStorageReadJournal.cs
@@ -9,13 +9,15 @@ using Akka.Streams.Dsl;
 
 namespace Akka.Persistence.Azure.Query
 {
-    public class AzureTableStorageReadJournal : IReadJournal,
+    public class AzureTableStorageReadJournal:
         IPersistenceIdsQuery,
         ICurrentPersistenceIdsQuery,
         IEventsByPersistenceIdQuery,
         ICurrentEventsByPersistenceIdQuery,
         IEventsByTagQuery,
-        ICurrentEventsByTagQuery
+        ICurrentEventsByTagQuery,
+        IAllEventsQuery,
+        ICurrentAllEventsQuery
     {
         public static string Identifier = "akka.persistence.query.journal.azure-table";
 
@@ -189,6 +191,16 @@ namespace Akka.Persistence.Azure.Query
                 default:
                     throw new ArgumentException($"{GetType().Name} does not support {offset.GetType().Name} offsets");
             }
+        }
+
+        public Source<EventEnvelope, NotUsed> AllEvents(Offset offset)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Source<EventEnvelope, NotUsed> CurrentAllEvents(Offset offset)
+        {
+            throw new NotImplementedException();
         }
     }
 

--- a/src/Akka.Persistence.Azure/Snapshot/AzureBlobSnapshotStoreSettings.cs
+++ b/src/Akka.Persistence.Azure/Snapshot/AzureBlobSnapshotStoreSettings.cs
@@ -6,7 +6,7 @@
 
 using System;
 using Akka.Configuration;
-using Microsoft.WindowsAzure.Storage;
+using Microsoft.Azure.Storage;
 
 namespace Akka.Persistence.Azure.Snapshot
 {
@@ -74,9 +74,9 @@ namespace Akka.Persistence.Azure.Snapshot
             var development = config.GetBoolean("development", false);
 
             return new AzureBlobSnapshotStoreSettings(
-                connectionString, 
-                containerName, 
-                connectTimeout, 
+                connectionString,
+                containerName,
+                connectTimeout,
                 requestTimeout,
                 verbose,
                 development);

--- a/src/Akka.Persistence.Azure/TableEntities/AllPersistenceIdsEntry.cs
+++ b/src/Akka.Persistence.Azure/TableEntities/AllPersistenceIdsEntry.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-using Microsoft.WindowsAzure.Storage;
-using Microsoft.WindowsAzure.Storage.Table;
+using Microsoft.Azure.Cosmos.Table;
 
 namespace Akka.Persistence.Azure.TableEntities
 {

--- a/src/Akka.Persistence.Azure/TableEntities/EventTagEntry.cs
+++ b/src/Akka.Persistence.Azure/TableEntities/EventTagEntry.cs
@@ -2,8 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using Akka.Persistence.Azure.Util;
-using Microsoft.WindowsAzure.Storage;
-using Microsoft.WindowsAzure.Storage.Table;
+using Microsoft.Azure.Cosmos.Table;
 
 namespace Akka.Persistence.Azure.TableEntities
 {

--- a/src/Akka.Persistence.Azure/TableEntities/HighestSequenceNrEntry.cs
+++ b/src/Akka.Persistence.Azure/TableEntities/HighestSequenceNrEntry.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-using Microsoft.WindowsAzure.Storage;
-using Microsoft.WindowsAzure.Storage.Table;
+using Microsoft.Azure.Cosmos.Table;
 
 namespace Akka.Persistence.Azure.TableEntities
 {

--- a/src/Akka.Persistence.Azure/TableEntities/PersistentJournalEntry.cs
+++ b/src/Akka.Persistence.Azure/TableEntities/PersistentJournalEntry.cs
@@ -6,8 +6,7 @@
 
 using Akka.Persistence.Azure.Journal;
 using Akka.Persistence.Azure.Util;
-using Microsoft.WindowsAzure.Storage;
-using Microsoft.WindowsAzure.Storage.Table;
+using Microsoft.Azure.Cosmos.Table;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/Akka.Persistence.Azure/TableEntities/SnapshotEntryTable.cs
+++ b/src/Akka.Persistence.Azure/TableEntities/SnapshotEntryTable.cs
@@ -1,0 +1,89 @@
+﻿using Akka.Persistence.Azure.Util;
+using Microsoft.Azure.Cosmos.Table;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+
+namespace Akka.Persistence.Azure.TableEntities
+{
+    internal sealed class SnapshotEntryTable: TableEntity
+    {
+        private const string SnapshotKeyName = "snapshot";
+        public const string SeqNoKeyName = "seqno";
+
+        public SnapshotEntryTable()
+        {
+
+        }
+        public SnapshotEntryTable(string persistentId, long seqNo, byte[] snapshot, DateTimeOffset timestamp)
+        {
+            PartitionKey = persistentId;
+            RowKey = seqNo.ToJournalRowKey();
+            Snapshot = snapshot;
+            Timestamp = timestamp;
+        }
+        /// <summary>
+        ///     The persistent snapshot
+        /// </summary>
+        public byte[] Snapshot { get; set; }
+        /// <summary>
+        ///     The sequence number.
+        /// </summary>
+        /// <remarks>
+        ///     We store this as a separate field since we may pad the <see cref="RowKey" />
+        ///     in order to get the rows for each partition to sort in descending order.
+        /// </remarks>
+        public long SeqNo { get; set; }
+
+        public override void ReadEntity(IDictionary<string, EntityProperty> properties, OperationContext operationContext)
+        {
+            // an exception is fine here - means the data is corrupted anyway
+            SeqNo = properties[SeqNoKeyName].Int64Value.Value;
+            Snapshot = properties[SnapshotKeyName].BinaryValue;
+        }
+
+        public override IDictionary<string, EntityProperty> WriteEntity(OperationContext operationContext)
+        {
+            var dict =
+                new Dictionary<string, EntityProperty>
+                {
+                    [SnapshotKeyName] = EntityProperty.GeneratePropertyForByteArray(Snapshot),
+                    [SeqNoKeyName] = EntityProperty.GeneratePropertyForLong(SeqNo)
+                };
+
+            return dict;
+        }
+    }
+
+    internal sealed class SnapshotItem
+    {
+        public SnapshotItem(string persistentId, long seqNo, byte[] snapshot, long timestamp)
+        {
+            //
+            Id = $"{persistentId}{seqNo}";
+            PersistenceId = persistentId;
+            Snapshot = snapshot;
+            Timestamp = timestamp;
+            SeqNo = seqNo;
+        }
+        [JsonProperty(PropertyName = "id")]
+        public string Id { get; set; }
+        /// <summary>
+        ///     The persistent snapshot
+        /// </summary>
+        public byte[] Snapshot { get; set; }
+        /// <summary>
+        ///     The sequence number.
+        /// </summary>
+        /// <remarks>
+        ///     We store this as a separate field since we may pad the <see cref="RowKey" />
+        ///     in order to get the rows for each partition to sort in descending order.
+        /// </remarks>
+        public long SeqNo { get; set; }
+        public long Timestamp { get; set; }
+        public string PersistenceId { get; set; }
+        public string PartitionKey => PersistenceId;
+        public static string PartitionKeyPath => "/PersistenceId";
+
+    }
+}

--- a/src/Akka.Persistence.Azure/TableEntities/SnapshotEntryTable.cs
+++ b/src/Akka.Persistence.Azure/TableEntities/SnapshotEntryTable.cs
@@ -75,10 +75,6 @@ namespace Akka.Persistence.Azure.TableEntities
         /// <summary>
         ///     The sequence number.
         /// </summary>
-        /// <remarks>
-        ///     We store this as a separate field since we may pad the <see cref="RowKey" />
-        ///     in order to get the rows for each partition to sort in descending order.
-        /// </remarks>
         public long SeqNo { get; set; }
         public long Timestamp { get; set; }
         public string PersistenceId { get; set; }

--- a/src/common.props
+++ b/src/common.props
@@ -14,8 +14,8 @@ Updates Akka version to 1.4.1</PackageReleaseNotes>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
   </PropertyGroup>
   <PropertyGroup>
-    <XunitVersion>2.4.1</XunitVersion>
-    <AkkaVersion>1.4.9</AkkaVersion>
+    <XunitVersion>2.4.3</XunitVersion>
+    <AkkaVersion>1.4.12</AkkaVersion>
     <TestSdkVersion>16.8.3</TestSdkVersion>
     <NetCoreTestVersion>netcoreapp3.1</NetCoreTestVersion>
     <NetFrameworkTestVersion>net461</NetFrameworkTestVersion>


### PR DESCRIPTION
I want to harvest your thoughts!

One of the blocker to modernizing the Azure plugin is that the **SnapshotStore** uses Blob Storage while the **JournalStore** is implemented with Table Storage.. Both Blob and Table APIs have been splitted into different packages namely: **Microsoft.Azure.Storage.Blob** and **Microsoft.Azure.Cosmos.Table** respectively - with both having different emulators supporting different container OSes.

But in this PR, I went with Cosmos SQL API(**Microsoft.Azure.Cosmos** - formerly Cosmos DocumentDB) because it is closer to MongoDB implementation.

I understand that one of the reason to use Blob storage is large content like files, videos, audio, pictures, but will the user ever have a snapshot larger than 2MB? If yes, in what use cases? Can't the user snaphot frequently to avoid the snapshot object growing to a size larger than, let say, 1.5MB?

Below are the changes I made for faster feedback (is this a positive route or should we stick with the old API and WHY?):

I created a Snapshot Item
````csharp
internal sealed class SnapshotItem
    {
        public SnapshotItem(string persistentId, long seqNo, byte[] snapshot, long timestamp)
        {
            //
            Id = $"{persistentId}{seqNo}";
            PersistenceId = persistentId;
            Snapshot = snapshot;
            Timestamp = timestamp;
            SeqNo = seqNo;
        }
        [JsonProperty(PropertyName = "id")]
        public string Id { get; set; }
        /// <summary>
        ///     The persistent snapshot
        /// </summary>
        public byte[] Snapshot { get; set; }
        /// <summary>
        ///     The sequence number.
        /// </summary>
        public long SeqNo { get; set; }
        public long Timestamp { get; set; }
        public string PersistenceId { get; set; }
        public string PartitionKey => PersistenceId;
        public static string PartitionKeyPath => "/PersistenceId";

    }
````
````csharp
private async Task<Container> InitContainer()
        {
            _cosmosDatabase = await _cosmosClient.CreateDatabaseIfNotExistsAsync(CosmosDatabaseId);
            ContainerProperties containerProperties = new ContainerProperties(id: _settings.ContainerName, partitionKeyPath: "/PersistenceId");
            containerProperties.IndexingPolicy.CompositeIndexes.Add(new System.Collections.ObjectModel.Collection<CompositePath>
            {   //Throws if not defined ==> 
                //"Errors":["The order by query does not have a corresponding composite index that it can be served from."
                new CompositePath 
                { 
                 Path = "/SeqNo", 
                 Order = CompositePathSortOrder.Descending            
                },
                new CompositePath
                {
                 Path = "/Timestamp",
                 Order = CompositePathSortOrder.Descending
                }
            });
            using (var cts = new CancellationTokenSource(_settings.ConnectTimeout))
            {
                var containerRef = await _cosmosDatabase.CreateContainerIfNotExistsAsync(
                containerProperties: containerProperties,
                throughput: 400, cancellationToken: cts.Token);

                //think about a proper log messages
                if (containerRef.StatusCode == System.Net.HttpStatusCode.OK)
                    _log.Info("Created Cosmos Container / Successfully connected to existing container", _settings.ContainerName);
                else
                    _log.Info("Successfully connected to existing container", _settings.ContainerName);

                return containerRef;
            }
        }
````
````csharp
protected override async Task<SelectedSnapshot> LoadAsync(string persistenceId,
            SnapshotSelectionCriteria criteria)
        {
            //need to improve these blocks
            var min = criteria.MinTimestamp.HasValue ? "AND s.Timestamp <= @toStamp" : "";
            QueryDefinition query = new QueryDefinition($"SELECT * FROM SnapshotItem s WHERE s.PersistenceId = @id " +
                $"AND (s.SeqNo > @fromSeqNo AND s.SeqNo <= @toSeqNo) AND (s.Timestamp >= @fromStamp {min})" +
                $"ORDER BY s.SeqNo DESC, s.Timestamp DESC")
               .WithParameter("@id", persistenceId)
               .WithParameter("@fromSeqNo", criteria.MinSequenceNr)
               .WithParameter("@toSeqNo", criteria.MaxSequenceNr)
               .WithParameter("@fromStamp", criteria.MinTimestamp.Value.Ticks);

            if (criteria.MinTimestamp.HasValue)
                query.WithParameter("@toStamp", criteria.MaxTimeStamp.Ticks);

            SelectedSnapshot selectedSnapshot = null;

            using (FeedIterator<SnapshotItem> setIterator = Container.GetItemQueryIterator<SnapshotItem>(
                query,
                requestOptions: new QueryRequestOptions()
                {
                    PartitionKey = new PartitionKey(persistenceId),
                    MaxConcurrency = 1,
                    MaxItemCount = 1
                }))
            {

                while (setIterator.HasMoreResults)
                {
                    FeedResponse<SnapshotItem> response = await setIterator.ReadNextAsync();
                    var resultItem = response.FirstOrDefault();//we only need the latest
                    if(resultItem != null)
                    {
                        var snapshot = _serialization.SnapshotFromBytes(resultItem.Snapshot);

                        selectedSnapshot =
                            new SelectedSnapshot(
                                new SnapshotMetadata(
                                    persistenceId,
                                    resultItem.SeqNo,
                                    new DateTime(resultItem.Timestamp)),
                                snapshot.Data);

                        break; //we are only interested in the first snapshot
                    }
                }

            }
            return selectedSnapshot;
        }
````
````csharp
protected override async Task SaveAsync(SnapshotMetadata metadata, object snapshot)
        {
            var snapshotData = _serialization.SnapshotToBytes(new Serialization.Snapshot(snapshot));

            var item = new SnapshotItem(metadata.PersistenceId, metadata.SequenceNr, snapshotData, metadata.Timestamp.Ticks);

            using (var cts = new CancellationTokenSource(_settings.RequestTimeout))
            {
                var upsert = await Container.UpsertItemAsync(item, new PartitionKey(item.PartitionKey), cancellationToken: cts.Token);
                _log.Info($"Upserted with statuscode: {upsert.StatusCode} persisttenceId: {upsert.Resource.PersistenceId}");
            }
        }
````
````csharp
protected override async Task DeleteAsync(SnapshotMetadata metadata)
        {
            using (var cts = new CancellationTokenSource(_settings.RequestTimeout))
            {
                var item = await Container.DeleteItemAsync<SnapshotItem>($"{metadata.PersistenceId}{metadata.SequenceNr}", 
                    new PartitionKey(metadata.PersistenceId), cancellationToken: cts.Token);
                if(item.StatusCode == System.Net.HttpStatusCode.NoContent)
                    _log.Info($"Deleted Snapshot: {metadata.PersistenceId}{metadata.SequenceNr}");
                else
                    _log.Info($"Failed to delete Snapshot: {metadata.PersistenceId}{metadata.SequenceNr}");
            }
        }
````
````csharp
protected override async Task DeleteAsync(string persistenceId, SnapshotSelectionCriteria criteria)
        {
            var min = criteria.MinTimestamp.HasValue ? "AND s.Timestamp <= @toStamp" : "";
            QueryDefinition query = new QueryDefinition($"SELECT * FROM SnapshotItem s WHERE s.PersistenceId = @id " +
                $"AND (s.SeqNo > @fromSeqNo AND s.SeqNo <= @toSeqNo) AND (s.Timestamp >= @fromStamp {min})" +
                $"ORDER BY s.SeqNo DESC, s.Timestamp DESC")
               .WithParameter("@id", persistenceId)
               .WithParameter("@fromSeqNo", criteria.MinSequenceNr)
               .WithParameter("@toSeqNo", criteria.MaxSequenceNr)
               .WithParameter("@fromStamp", criteria.MinTimestamp.Value.Ticks);

            if (criteria.MinTimestamp.HasValue)
                query.WithParameter("@toStamp", criteria.MaxTimeStamp.Ticks);

            using (FeedIterator<SnapshotItem> setIterator = Container.GetItemQueryIterator<SnapshotItem>(
                query,
                requestOptions: new QueryRequestOptions()
                {
                    PartitionKey = new PartitionKey(persistenceId),
                    MaxConcurrency = 1,
                    MaxItemCount = 1
                }))
            {
                //make this better?
                using (var cts = new CancellationTokenSource(_settings.RequestTimeout))
                {
                    while (setIterator.HasMoreResults)
                    {
                        FeedResponse<SnapshotItem> response = await setIterator.ReadNextAsync();
                        foreach (var i in response.Resource)
                        {
                            var item = await Container.DeleteItemAsync<SnapshotItem>($"{i.PersistenceId}{i.SeqNo}", 
                                new PartitionKey(i.PersistenceId), cancellationToken: cts.Token);
                            if (item.StatusCode == System.Net.HttpStatusCode.NoContent)
                                _log.Info($"Deleted Snapshot: {i.PersistenceId}{i.SeqNo}");
                            else
                                _log.Info($"Failed to delete Snapshot: {i.PersistenceId}{i.SeqNo}");
                        }                            
                        
                    }
                }
            }
        }
`````