### PR TITLE
Problem with implimentation of akka persistence contract

### DIFF
--- a/src/Akka.Persistence.Azure/Journal/AzureTableStorageJournal.cs
+++ b/src/Akka.Persistence.Azure/Journal/AzureTableStorageJournal.cs
@@ -388,6 +388,8 @@ namespace Akka.Persistence.Azure.Journal
                         }
                         catch (Exception ex)
                         {
+                            _log.Warning(ex, "Failure while writing messages to Azure table storage");
+                        
                             exceptions = exceptions.Add(ex);
                         }
                     }

--- a/src/Akka.Persistence.Azure/Journal/AzureTableStorageJournal.cs
+++ b/src/Akka.Persistence.Azure/Journal/AzureTableStorageJournal.cs
@@ -383,6 +383,8 @@ namespace Akka.Persistence.Azure.Journal
                             if (_log.IsDebugEnabled && _settings.VerboseLogging)
                                 foreach (var r in persistenceResults)
                                     _log.Debug("Azure table storage wrote entity [{0}] with status code [{1}]", r.Etag, r.HttpStatusCode);
+
+                            exceptions = exceptions.Add(null);
                         }
                         catch (Exception ex)
                         {
@@ -391,7 +393,7 @@ namespace Akka.Persistence.Azure.Journal
                     }
                 }
 
-                if (exceptions.IsEmpty)
+                if (exceptions.All(ex => ex == null))
                 {
                     var allPersistenceIdsBatch = new TableBatchOperation();
 
@@ -439,7 +441,6 @@ namespace Akka.Persistence.Azure.Journal
                                     NotifyTagChange(tag);
                                 }
                             }
-
                         }
                     }
                 }
@@ -451,7 +452,7 @@ namespace Akka.Persistence.Azure.Journal
                  *
                  * Either everything fails or everything succeeds is the idea I guess.
                  */
-                return exceptions.IsEmpty ? null : exceptions;
+                return exceptions.Any(ex => ex != null) ? exceptions : null;
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
We ran in to a issue where if at least one AtomicWrite failed while at least one succeeded then the persistence actor would fail (instead of replying with a rejected message). This seem to be because of the following validation: 
https://github.com/akkadotnet/akka.net/blob/dev/src/core/Akka.Persistence/Journal/AsyncWriteJournal.cs#L393.
This PR should implement the contract correctly to get the expected response. 