### PR TITLE
Limiting batch size for table storage

### DIFF
--- a/src/Akka.Persistence.Azure/CloudTableExtensions.cs
+++ b/src/Akka.Persistence.Azure/CloudTableExtensions.cs
@@ -1,0 +1,46 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.WindowsAzure.Storage.Table;
+
+namespace Akka.Persistence.Azure
+{
+    public static class CloudTableExtensions
+    {
+        private const int MaxBatchSize = 100;
+        
+        public static async Task<IList<TableResult>> ExecuteBatchAsLimitedBatches(
+            this CloudTable table,
+            TableBatchOperation batch)
+        {
+            if (batch.Count < 1)
+                return new List<TableResult>();
+            
+            if (batch.Count <= MaxBatchSize)
+                return await table.ExecuteBatchAsync(batch);
+
+            var result = new List<TableResult>();
+            var limitedBatchOperationLists = batch.ChunkBy(MaxBatchSize);
+            
+            foreach (var limitedBatchOperationList in limitedBatchOperationLists)
+            {
+                var limitedBatch = CreateLimitedTableBatchOperation(limitedBatchOperationList);
+                var limitedBatchResult = await table.ExecuteBatchAsync(limitedBatch);
+                result.AddRange(limitedBatchResult);
+            }
+
+            return result;
+        }
+
+        private static TableBatchOperation CreateLimitedTableBatchOperation(
+            IEnumerable<TableOperation> limitedBatchOperationList)
+        {
+            var limitedBatch = new TableBatchOperation();
+            foreach (var limitedBatchOperation in limitedBatchOperationList)
+            {
+                limitedBatch.Add(limitedBatchOperation);
+            }
+
+            return limitedBatch;
+        }
+    }
+}

--- a/src/Akka.Persistence.Azure/Journal/AzureTableStorageJournal.cs
+++ b/src/Akka.Persistence.Azure/Journal/AzureTableStorageJournal.cs
@@ -223,7 +223,7 @@ namespace Akka.Persistence.Azure.Journal
                         tableBatchOperation.Delete(toBeDeleted);
                     }
 
-                    var deleteTask = Table.ExecuteBatchAsync(tableBatchOperation);
+                    var deleteTask = Table.ExecuteBatchAsLimitedBatches(tableBatchOperation);
 
                     await deleteTask;
                 }
@@ -378,7 +378,7 @@ namespace Akka.Persistence.Azure.Journal
                             if (_log.IsDebugEnabled && _settings.VerboseLogging)
                                 _log.Debug("Attempting to write batch of {0} messages to Azure storage", persistenceBatch.Count);
 
-                            var persistenceResults = await Table.ExecuteBatchAsync(persistenceBatch);
+                            var persistenceResults = await Table.ExecuteBatchAsLimitedBatches(persistenceBatch);
 
                             if (_log.IsDebugEnabled && _settings.VerboseLogging)
                                 foreach (var r in persistenceResults)
@@ -401,7 +401,7 @@ namespace Akka.Persistence.Azure.Journal
                         allPersistenceIdsBatch.InsertOrReplace(new AllPersistenceIdsEntry(encodedKey));
                     });
 
-                    var allPersistenceResults = await Table.ExecuteBatchAsync(allPersistenceIdsBatch);
+                    var allPersistenceResults = await Table.ExecuteBatchAsLimitedBatches(allPersistenceIdsBatch);
 
                     if (_log.IsDebugEnabled && _settings.VerboseLogging)
                         foreach (var r in allPersistenceResults)
@@ -426,7 +426,7 @@ namespace Akka.Persistence.Azure.Journal
                                 eventTagsBatch.InsertOrReplace(item);
                             }
 
-                            var eventTagsResults = await Table.ExecuteBatchAsync(eventTagsBatch);
+                            var eventTagsResults = await Table.ExecuteBatchAsLimitedBatches(eventTagsBatch);
 
                             if (_log.IsDebugEnabled && _settings.VerboseLogging)
                                 foreach (var r in eventTagsResults)

--- a/src/Akka.Persistence.Azure/ListExtensions.cs
+++ b/src/Akka.Persistence.Azure/ListExtensions.cs
@@ -1,0 +1,18 @@
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+
+namespace Akka.Persistence.Azure
+{
+    public static class ListExtensions
+    {
+        public static IImmutableList<IEnumerable<T>> ChunkBy<T>(this IEnumerable<T> source, int chunkSize)
+        {
+            return source
+                .Select((x, i) => new { Index = i, Value = x })
+                .GroupBy(x => x.Index / chunkSize)
+                .Select(x => x.Select(v => v.Value).ToList().AsEnumerable())
+                .ToImmutableList();
+        }
+    }
+}


### PR DESCRIPTION
We've had a issue where we've hit the batch limit for table storage (max 100 items per batch). This is the fix we've used on our end.