### PR TITLE
Remove legacy AllocatesAllPersistenceIDsPublisher in AzureTablePersistenceIdsSpec

### DIFF
--- a/src/Akka.Persistence.Azure.Tests/Query/AzureTablePersistenceIdsSpec.cs
+++ b/src/Akka.Persistence.Azure.Tests/Query/AzureTablePersistenceIdsSpec.cs
@@ -22,7 +22,5 @@ namespace Akka.Persistence.Azure.Tests.Query
                 Sys.ReadJournalFor<AzureTableStorageReadJournal>(
                     AzureTableStorageReadJournal.Identifier);
         }
-
-        protected override bool AllocatesAllPersistenceIDsPublisher => false;
     }
 }


### PR DESCRIPTION
Fixes #130