### PR TITLE
Update RELEASE_NOTES.md for 1.5.13 release

### DIFF
--- a/Akka.Persistence.Azure.sln
+++ b/Akka.Persistence.Azure.sln
@@ -19,6 +19,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "build", "build", "{320BFA6C
 		src\Directory.Packages.props = src\Directory.Packages.props
 		src\xunitRunner.props = src\xunitRunner.props
 		src\Directory.Generated.props = src\Directory.Generated.props
+		README.md = README.md
+		RELEASE_NOTES.md = RELEASE_NOTES.md
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Akka.Persistence.Azure.Hosting", "src\Akka.Persistence.Azure.Hosting\Akka.Persistence.Azure.Hosting.csproj", "{64C6B877-9262-456B-8A1C-60C4F272DA19}"

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,11 @@
+#### 1.5.13 October 6 2023 ####
+
+* [Update Akka.NET v1.5.13](https://github.com/akkadotnet/akka.net/releases/tag/1.5.13)
+* [Update Akka.Hosting v1.5.13](https://github.com/akkadotnet/Akka.Hosting/releases/tag/1.5.13) 
+* [Bump Azure.Storage.Blobs to 12.18.0](https://github.com/petabridge/Akka.Persistence.Azure/pull/337)
+* [Bump Azure.Data.Tables to 12.18.1](https://github.com/petabridge/Akka.Persistence.Azure/pull/337)
+* [Bump Azure.Identity to 1.10.1](https://github.com/petabridge/Akka.Persistence.Azure/pull/338)
+
 #### 1.5.1 March 16 2023 ####
 
 * [Update Akka.NET v1.5.1](https://github.com/akkadotnet/akka.net/releases/tag/1.5.1)


### PR DESCRIPTION
## 1.5.13 October 6 2023 

* [Update Akka.NET v1.5.13](https://github.com/akkadotnet/akka.net/releases/tag/1.5.13)
* [Update Akka.Hosting v1.5.13](https://github.com/akkadotnet/Akka.Hosting/releases/tag/1.5.13) 
* [Bump Azure.Storage.Blobs to 12.18.0](https://github.com/petabridge/Akka.Persistence.Azure/pull/337)
* [Bump Azure.Data.Tables to 12.18.1](https://github.com/petabridge/Akka.Persistence.Azure/pull/337)
* [Bump Azure.Identity to 1.10.1](https://github.com/petabridge/Akka.Persistence.Azure/pull/338)