### PR TITLE
Fix broken tag query message replay logic

### DIFF
--- a/src/Akka.Persistence.Azure.Tests/Query/AzureTableCurrentEventsByTagSpec.cs
+++ b/src/Akka.Persistence.Azure.Tests/Query/AzureTableCurrentEventsByTagSpec.cs
@@ -1,12 +1,19 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Configuration;
+using Akka.Event;
 using Akka.Persistence.Azure.Query;
 using Akka.Persistence.Azure.Tests.Helper;
 using Akka.Persistence.Query;
 using Akka.Persistence.TCK.Query;
+using Akka.Streams.TestKit;
+using FluentAssertions;
 using Xunit;
 using Xunit.Abstractions;
+using Xunit.Sdk;
 using static Akka.Persistence.Azure.Tests.Helper.AzureStorageConfigHelper;
 
 namespace Akka.Persistence.Azure.Tests.Query
@@ -32,5 +39,67 @@ namespace Akka.Persistence.Azure.Tests.Query
         }
 
         public static string TableName { get; private set; }
+
+        [Fact(DisplayName = "Read journal should be able to retrieve all tagged persisted messages beyond the first 1000 messages")]
+        public async Task RetrieveAllTaggedRows()
+        {
+            if (ReadJournal is not ICurrentEventsByTagQuery queries)
+                throw IsTypeException.ForMismatchedType(nameof(ICurrentEventsByTagQuery), ReadJournal?.GetType().Name ?? "null");
+
+            var allMessages = Enumerable.Range(0, 2000)
+                .Select(i => $"green {i}").ToArray();
+            var a = Sys.ActorOf(TestPersistenceActor.Props("a"));
+            foreach (var str in allMessages)
+            {
+                a.Tell(str);
+                ExpectMsg($"{str}-done");
+            }
+
+            var probe = queries.CurrentEventsByTag("green", Offset.NoOffset())
+                .RunWith(this.SinkProbe<EventEnvelope>(), Materializer);
+
+            await probe.ExpectSubscriptionAsync();
+            probe.Request(3000);
+            
+            var received = new List<string>();
+            foreach (var _ in Enumerable.Range(0, 2000))
+            {
+                var env = await probe.ExpectNextAsync();
+                received.Add((string)env.Event);
+            }
+
+            await probe.ExpectCompleteAsync();
+            received.Should().BeEquivalentTo(allMessages);
+        }
+
+        private sealed class TestPersistenceActor : UntypedPersistentActor
+        {
+            public static Props Props(string persistenceId) => Actor.Props.Create(() => new TestPersistenceActor(persistenceId));
+
+            public TestPersistenceActor(string persistenceId)
+            {
+                PersistenceId = persistenceId;
+            }
+
+            public override string PersistenceId { get; }
+
+            protected override void OnRecover(object message)
+            {
+            }
+
+            protected override void OnCommand(object message)
+            {
+                switch (message)
+                {
+                    case string cmd:
+                        var sender = Sender;
+                        Persist(cmd, e => sender.Tell($"{e}-done"));
+                        break;
+                    default:
+                        Unhandled(message);
+                        break;
+                }
+            }
+        }
     }
 }

--- a/src/Akka.Persistence.Azure.Tests/Query/AzureTableCurrentEventsByTagSpec.cs
+++ b/src/Akka.Persistence.Azure.Tests/Query/AzureTableCurrentEventsByTagSpec.cs
@@ -52,8 +52,8 @@ namespace Akka.Persistence.Azure.Tests.Query
             foreach (var str in allMessages)
             {
                 a.Tell(str);
-                ExpectMsg($"{str}-done");
             }
+            ReceiveN(2000);
 
             var probe = queries.CurrentEventsByTag("green", Offset.NoOffset())
                 .RunWith(this.SinkProbe<EventEnvelope>(), Materializer);

--- a/src/Akka.Persistence.Azure/Akka.Persistence.Azure.csproj
+++ b/src/Akka.Persistence.Azure/Akka.Persistence.Azure.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>$(NetStandardLibVersion);$(NetVersion)</TargetFrameworks>
     <Description>Akka.Persistence support for Windows Azure Table storage and Azure blob storage.</Description>
-    <LangVersion>8.0</LangVersion>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Akka.Persistence.Azure/Journal/AzureTableStorageJournal.cs
+++ b/src/Akka.Persistence.Azure/Journal/AzureTableStorageJournal.cs
@@ -721,7 +721,6 @@ namespace Akka.Persistence.Azure.Journal
             // In order to actually break at the limit we ask for we have to
             //    keep a separate counter and track it ourselves.
             var counter = 0;
-            var currentOrderingId = 0L;
             var maxPerPage = Math.Min(replay.Max, 1000);
 
             await using var pages = TaggedMessageQuery(replay, (int)maxPerPage, cancellationToken).AsPages().GetAsyncEnumerator(cancellationToken);
@@ -755,8 +754,6 @@ namespace Akka.Persistence.Azure.Journal
                         counter++;
                     }
 
-                    currentOrderingId = Math.Max(currentOrderingId, entry.UtcTicks);
-                    
                     if (counter >= replay.Max)
                         return new ReplayTaggedMessageSuccess(false);
                 }

--- a/src/Akka.Persistence.Azure/Journal/AzureTableStorageJournal.cs
+++ b/src/Akka.Persistence.Azure/Journal/AzureTableStorageJournal.cs
@@ -285,7 +285,7 @@ namespace Akka.Persistence.Azure.Journal
             {
                 case ReplayTaggedMessages replay:
                     ReplayTaggedMessagesAsync(replay, _shutdownCts.Token)
-                        .PipeTo(replay.ReplyTo, success: h => new RecoverySuccess(h), failure: e => new ReplayMessagesFailure(e));
+                        .PipeTo(replay.ReplyTo, failure: e => new ReplayMessagesFailure(e));
                     break;
                 case SubscribePersistenceId subscribe:
                     AddPersistenceIdSubscriber(Sender, subscribe.PersistenceId);
@@ -716,29 +716,23 @@ namespace Akka.Persistence.Azure.Journal
         /// <param name="replay">TBD</param>
         /// <param name="cancellationToken"></param>
         /// <returns>TBD</returns>
-        private async Task<long> ReplayTaggedMessagesAsync(ReplayTaggedMessages replay, CancellationToken cancellationToken)
+        private async Task<ReplayTaggedMessageSuccess> ReplayTaggedMessagesAsync(ReplayTaggedMessages replay, CancellationToken cancellationToken)
         {
             // In order to actually break at the limit we ask for we have to
             //    keep a separate counter and track it ourselves.
             var counter = 0;
-            var maxOrderingId = 0L;
+            var currentOrderingId = 0L;
+            var maxPerPage = Math.Min(replay.Max, 1000);
 
-            var pages = TaggedMessageQuery(replay, null, cancellationToken).AsPages().GetAsyncEnumerator(cancellationToken);
-            ValueTask<bool>? nextTask = pages.MoveNextAsync();
-            
-            while (nextTask != null)
+            await using var pages = TaggedMessageQuery(replay, (int)maxPerPage, cancellationToken).AsPages().GetAsyncEnumerator(cancellationToken);
+            while (await pages.MoveNextAsync())
             {
-                await nextTask.Value;
                 var currentPage = pages.Current;
-
-                if (currentPage.ContinuationToken != null)
-                    nextTask = pages.MoveNextAsync();
-                else
-                    nextTask = null;
-                
                 foreach (var entry in currentPage.Values.Select(entity => new EventTagEntry(entity)).OrderBy(x => x.UtcTicks))
                 {
                     var deserialized = _serialization.PersistentFromBytes(entry.Payload);
+                    if (entry.UtcTicks >= replay.ToOffset)
+                        return new ReplayTaggedMessageSuccess(true);
 
                     var persistent =
                         new Persistent(
@@ -761,16 +755,17 @@ namespace Akka.Persistence.Azure.Journal
                         counter++;
                     }
 
-                    maxOrderingId = Math.Max(maxOrderingId, entry.UtcTicks);
+                    currentOrderingId = Math.Max(currentOrderingId, entry.UtcTicks);
+                    
+                    if (counter >= replay.Max)
+                        return new ReplayTaggedMessageSuccess(false);
                 }
 
                 if (counter >= replay.Max)
-                {
-                    break;
-                }
+                    return new ReplayTaggedMessageSuccess(false);
             }
 
-            return maxOrderingId;
+            return new ReplayTaggedMessageSuccess(true);
         }
 
         private bool TryAddPersistenceId(string persistenceId)

--- a/src/Akka.Persistence.Azure/Query/AzureTableStorageReadJournal.cs
+++ b/src/Akka.Persistence.Azure/Query/AzureTableStorageReadJournal.cs
@@ -194,18 +194,19 @@ namespace Akka.Persistence.Azure.Query
         /// </summary>
         public Source<EventEnvelope, NotUsed> CurrentEventsByTag(string tag, Offset offset = null)
         {
-            offset = offset ?? new Sequence(0L);
-            switch (offset)
+            offset = offset switch
             {
-                case Sequence seq:
-                    return Source.ActorPublisher<EventEnvelope>(EventsByTagPublisher.Props(tag, seq.Value, DateTime.UtcNow.Ticks, null, _maxBufferSize, _writeJournalPluginId))
-                        .MapMaterializedValue(_ => NotUsed.Instance)
-                        .Named($"CurrentEventsByTag-{tag}");
-                case NoOffset _:
-                    return CurrentEventsByTag(tag, new Sequence(0L));
-                default:
-                    throw new ArgumentException($"{GetType().Name} does not support {offset.GetType().Name} offsets");
-            }
+                null => new Sequence(0L),
+                NoOffset _ => new Sequence(0L),
+                _ => offset
+            };
+            
+            if(offset is not Sequence seq)
+                throw new ArgumentException($"{GetType().Name} does not support {offset.GetType().Name} offsets");
+            
+            return Source.ActorPublisher<EventEnvelope>(EventsByTagPublisher.Props(tag, seq.Value, DateTime.UtcNow.Ticks, null, _maxBufferSize, _writeJournalPluginId))
+                .MapMaterializedValue(_ => NotUsed.Instance)
+                .Named($"CurrentEventsByTag-{tag}");
         }
     }
 

--- a/src/Akka.Persistence.Azure/Query/AzureTableStorageReadJournal.cs
+++ b/src/Akka.Persistence.Azure/Query/AzureTableStorageReadJournal.cs
@@ -198,7 +198,7 @@ namespace Akka.Persistence.Azure.Query
             switch (offset)
             {
                 case Sequence seq:
-                    return Source.ActorPublisher<EventEnvelope>(EventsByTagPublisher.Props(tag, seq.Value, long.MaxValue, null, _maxBufferSize, _writeJournalPluginId))
+                    return Source.ActorPublisher<EventEnvelope>(EventsByTagPublisher.Props(tag, seq.Value, DateTime.UtcNow.Ticks, null, _maxBufferSize, _writeJournalPluginId))
                         .MapMaterializedValue(_ => NotUsed.Instance)
                         .Named($"CurrentEventsByTag-{tag}");
                 case NoOffset _:

--- a/src/Akka.Persistence.Azure/Query/Messages.cs
+++ b/src/Akka.Persistence.Azure/Query/Messages.cs
@@ -172,6 +172,16 @@ namespace Akka.Persistence.Azure.Query
         }
     }
 
+    public sealed class ReplayTaggedMessageSuccess
+    {
+        public ReplayTaggedMessageSuccess(bool completed)
+        {
+            Completed = completed;
+        }
+
+        public bool Completed { get; }
+    }
+
     /// <summary>
     /// Subscribe the `sender` to current and new persistenceIds.
     /// Used by query-side. The journal will send one <see cref="CurrentPersistenceIds"/> to the

--- a/src/Akka.Persistence.Azure/Query/Publishers/AbstractEventsByTagPublisher.cs
+++ b/src/Akka.Persistence.Azure/Query/Publishers/AbstractEventsByTagPublisher.cs
@@ -28,7 +28,7 @@ namespace Akka.Persistence.Azure.Query.Publishers
             JournalRef = Persistence.Instance.Apply(Context.System).JournalFor(writeJournalPluginId);
         }
 
-        protected ILoggingAdapter Log => _log ?? (_log = Context.GetLogger());
+        protected ILoggingAdapter Log => _log ??= Context.GetLogger();
         protected string Tag { get; }
         protected long FromOffset { get; }
         protected abstract long ToOffset { get; }
@@ -39,7 +39,7 @@ namespace Akka.Persistence.Azure.Query.Publishers
 
         protected abstract void ReceiveInitialRequest();
         protected abstract void ReceiveIdleRequest();
-        protected abstract void ReceiveRecoverySuccess(long highestSequenceNr);
+        protected abstract void ReceiveRecoverySuccess(bool completed);
 
         protected override bool Receive(object message)
         {
@@ -106,9 +106,9 @@ namespace Akka.Persistence.Azure.Query.Publishers
                     Buffer.DeliverBuffer(TotalDemand);
                     return true;
                 
-                case RecoverySuccess success:
-                    Log.Debug("replay completed for tag [{0}], currOffset [{1}]", Tag, CurrentOffset);
-                    ReceiveRecoverySuccess(success.HighestSequenceNr);
+                case ReplayTaggedMessageSuccess success:
+                    Log.Debug("replay completed for tag [{0}], currOffset [{1}], completed: {2}", Tag, CurrentOffset, success.Completed);
+                    ReceiveRecoverySuccess(success.Completed);
                     return true;
                 
                 case ReplayMessagesFailure failure:

--- a/src/Akka.Persistence.Azure/Query/Publishers/CurrentEventsByTagPublisher.cs
+++ b/src/Akka.Persistence.Azure/Query/Publishers/CurrentEventsByTagPublisher.cs
@@ -11,7 +11,7 @@ namespace Akka.Persistence.Azure.Query.Publishers
     internal sealed class CurrentEventsByTagPublisher 
         : AbstractEventsByTagPublisher
     {
-        private long _toOffset;
+        private bool _completed;
 
         public CurrentEventsByTagPublisher(
             string tag, 
@@ -21,16 +21,16 @@ namespace Akka.Persistence.Azure.Query.Publishers
             string writeJournalPluginId)
             : base(tag, fromOffset, maxBufferSize, writeJournalPluginId)
         {
-            _toOffset = toOffset;
+            ToOffset = toOffset;
         }
 
-        protected override long ToOffset => _toOffset;
+        protected override long ToOffset { get; }
 
         protected override void ReceiveIdleRequest()
         {
             Buffer.DeliverBuffer(TotalDemand);
 
-            if (Buffer.IsEmpty && CurrentOffset > ToOffset)
+            if (Buffer.IsEmpty && _completed)
                 OnCompleteThenStop();
             else
                 Self.Tell(EventsByTagPublisher.Continue.Instance);
@@ -41,14 +41,14 @@ namespace Akka.Persistence.Azure.Query.Publishers
             Replay();
         }
 
-        protected override void ReceiveRecoverySuccess(long highestSequenceNr)
+        protected override void ReceiveRecoverySuccess(bool completed)
         {
+            if (completed)
+                _completed = true;
+            
             Buffer.DeliverBuffer(TotalDemand);
 
-            if (highestSequenceNr < ToOffset)
-                _toOffset = highestSequenceNr;
-
-            if (Buffer.IsEmpty && CurrentOffset > ToOffset)
+            if (Buffer.IsEmpty && _completed)
                 OnCompleteThenStop();
             else
                 Self.Tell(EventsByTagPublisher.Continue.Instance);

--- a/src/Akka.Persistence.Azure/Query/Publishers/LiveEventsByTagPublisher.cs
+++ b/src/Akka.Persistence.Azure/Query/Publishers/LiveEventsByTagPublisher.cs
@@ -47,7 +47,7 @@ namespace Akka.Persistence.Azure.Query.Publishers
                 OnCompleteThenStop();
         }
 
-        protected override void ReceiveRecoverySuccess(long highestSequenceNr)
+        protected override void ReceiveRecoverySuccess(bool completed)
         {
             Buffer.DeliverBuffer(TotalDemand);
             if (Buffer.IsEmpty && CurrentOffset > ToOffset)


### PR DESCRIPTION
Fixes #385

## Changes
* Change `AzureTableStorageReadJournal.CurrentEventsByTag` `toOffset` to `DateTime.UtcNow.Ticks` to enable query limiting
* Change how `AzureTableStorageReadJournal.ReplayTaggedMessagesAsync()` signals if it reaches the end of records
* Limit the number of record fetch to limit network bandwidth waste
* Fix `CurrentEventsByTagPublisher` logic to determine completion from the read journal return status.