### PR TITLE
Port akkadotnet/akka.net#7313: Made `DateTime.UtcNow` the default timestamp for `SnapshotMetdata`

### DIFF
--- a/src/Akka.Persistence.Azure/Snapshot/AzureBlobSnapshotStore.cs
+++ b/src/Akka.Persistence.Azure/Snapshot/AzureBlobSnapshotStore.cs
@@ -260,7 +260,13 @@ namespace Akka.Persistence.Azure.Snapshot
             cts.CancelAfter(_settings.RequestTimeout);
             using (cts)
             {
-                await blobClient.DeleteIfExistsAsync(cancellationToken: cts.Token);
+                var response = await blobClient.DownloadAsync(cts.Token);
+                if (response.HasValue)
+                {
+                    var timestamp = new DateTime(long.Parse(response.Value.Details.Metadata[TimeStampMetaDataKey])); 
+                    if(timestamp <= metadata.Timestamp)
+                        await blobClient.DeleteAsync(cancellationToken: cts.Token);
+                }
             }
         }
 

--- a/src/Akka.Persistence.Azure/Snapshot/AzureBlobSnapshotStore.cs
+++ b/src/Akka.Persistence.Azure/Snapshot/AzureBlobSnapshotStore.cs
@@ -260,10 +260,10 @@ namespace Akka.Persistence.Azure.Snapshot
             cts.CancelAfter(_settings.RequestTimeout);
             using (cts)
             {
-                var response = await blobClient.DownloadAsync(cts.Token);
+                var response = await blobClient.GetPropertiesAsync(cancellationToken: cts.Token);
                 if (response.HasValue)
                 {
-                    var timestamp = new DateTime(long.Parse(response.Value.Details.Metadata[TimeStampMetaDataKey])); 
+                    var timestamp = new DateTime(long.Parse(response.Value.Metadata[TimeStampMetaDataKey])); 
                     if(timestamp <= metadata.Timestamp)
                         await blobClient.DeleteAsync(cancellationToken: cts.Token);
                 }


### PR DESCRIPTION
## Changes

Make sure that `AzureBlobSnapshotStore.DeleteAsync()` takes the metadata timestamp into account when deleting snapshots.