### PR TITLE
Add `Persistence.DefaultConfig` during start-up

### DIFF
--- a/src/Akka.Persistence.Azure.Hosting/AzurePersistenceExtensions.cs
+++ b/src/Akka.Persistence.Azure.Hosting/AzurePersistenceExtensions.cs
@@ -268,6 +268,9 @@ namespace Akka.Persistence.Azure.Hosting
             options.Apply(builder);
             builder.AddHocon(options.DefaultConfig, HoconAddMode.Append);
             
+            // Need to add persistence default settings to make sure that persistence message serializer is loaded properly
+            builder.AddHocon(Persistence.DefaultConfig(), HoconAddMode.Append);
+            
             return builder;
         }
         
@@ -486,6 +489,9 @@ namespace Akka.Persistence.Azure.Hosting
             builder.AddHocon(options.ToConfig(), HoconAddMode.Prepend);
             options.Apply(builder);
             builder.AddHocon(options.DefaultConfig, HoconAddMode.Append);
+            
+            // Need to add persistence default settings to make sure that persistence snapshot message serializer is loaded properly
+            builder.AddHocon(Persistence.DefaultConfig(), HoconAddMode.Append);
 
             return builder;
         }


### PR DESCRIPTION
There are cases where a race condition would happen and a persistent actor would start recovery before the `Persistence` plugin were started, this would cause the `PersistenceMessageSerializer` and `PersistenceSnapshotSerializer` to be missing and all `IPersistentRepresentation` messages to be deserialized by the default object serializer instead of the proper protobuf serializer.

In case of `Hyperion` as the default object serializer, this would cause a very cryptic exception to be thrown:
```
System.Runtime.Serialization.SerializationException: Failed to deserialize instance of type Akka.Persistence.IPersistentRepresentation. Offset must be specified in whole minutes. (Parameter 'offset')
```

## Changes
* Make sure that `Persistence.DefaultConfig()` is applied as fallback config when journal or snapshot is being configured.