### PR TITLE
Fix ClusterShardingSpec

### DIFF
--- a/src/Akka.Persistence.Azure.Tests/ClusterShardingSpec.cs
+++ b/src/Akka.Persistence.Azure.Tests/ClusterShardingSpec.cs
@@ -117,6 +117,7 @@ public class ClusterShardingSpec: Akka.TestKit.Xunit2.TestKit, IAsyncLifetime
         // recovery test, shard actor should wake up and recover
         _shardRegion.Tell(new ShardEnvelope(PId, "die"));
         await _probe.ExpectTerminatedAsync(persistActor);
+        await Task.Delay(20);
 
         _shardRegion.Tell(new ShardEnvelope(PId, "wake-up"));
         var newPersistActor = _probe.ExpectMsg<IActorRef>();
@@ -129,6 +130,7 @@ public class ClusterShardingSpec: Akka.TestKit.Xunit2.TestKit, IAsyncLifetime
         // recovery test, shard actor should wake up and recover after state reset
         _shardRegion.Tell(new ShardEnvelope(PId, "reset"));
         await _probe.ExpectTerminatedAsync(newPersistActor);
+        await Task.Delay(20);
         
         _shardRegion.Tell(new ShardEnvelope(PId, "wake-up"));
         var resetActor = _probe.ExpectMsg<IActorRef>();
@@ -174,6 +176,7 @@ public class ClusterShardingSpec: Akka.TestKit.Xunit2.TestKit, IAsyncLifetime
             oldActor = persistActor;
             _shardRegion.Tell(new ShardEnvelope(PId, "reset"));
             await _probe.ExpectTerminatedAsync(persistActor);
+            await Task.Delay(20);
         }
     }
     


### PR DESCRIPTION
Fix race condition on both unit test.

There's a race condition between the probe receiving the entity actor `Terminated` message and the shard region processing the entity actor `Terminated` message. A message can be lost if it arrived after the actor invoked `Context.Stop(Self)` but before the shard region actor processed the entity actor `Terminated` message.