### PR TITLE
Fix possible auth caching issue

### DIFF
--- a/src/Akka.Persistence.Azure/Journal/AzureTableStorageJournal.cs
+++ b/src/Akka.Persistence.Azure/Journal/AzureTableStorageJournal.cs
@@ -18,6 +18,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Akka.Configuration;
+using Akka.Util;
 using Azure;
 using Azure.Data.Tables;
 using Debug = System.Diagnostics.Debug;
@@ -51,10 +52,9 @@ namespace Akka.Persistence.Azure.Journal
         private readonly Dictionary<string, ISet<IActorRef>> _persistenceIdSubscribers = new Dictionary<string, ISet<IActorRef>>();
         private readonly SerializationHelper _serialization;
         private readonly AzureTableStorageJournalSettings _settings;
-        private readonly TableServiceClient _tableServiceClient;
-        private TableClient _tableStorage_DoNotUseDirectly;
         private readonly Dictionary<string, ISet<IActorRef>> _tagSubscribers = new Dictionary<string, ISet<IActorRef>>();
         private readonly CancellationTokenSource _shutdownCts;
+        private AtomicBoolean _initialized = new();
 
         public AzureTableStorageJournal(Config config = null)
         {
@@ -77,21 +77,6 @@ namespace Akka.Persistence.Azure.Journal
             
             _serialization = new SerializationHelper(Context.System);
 
-            if (_settings.Development)
-            {
-                _tableServiceClient = new TableServiceClient(connectionString: "UseDevelopmentStorage=true");
-            }
-            else
-            {
-                // Use TokenCredential if both ServiceUri and TokenCredential are populated in the settings 
-                _tableServiceClient = _settings.ServiceUri != null && _settings.AzureCredential != null
-                    ? new TableServiceClient(
-                        endpoint: _settings.ServiceUri,
-                        tokenCredential: _settings.AzureCredential,
-                        options: _settings.TableClientOptions)
-                    : new TableServiceClient(connectionString: _settings.ConnectionString);
-            }
-
             _shutdownCts = new CancellationTokenSource();
         }
 
@@ -99,9 +84,9 @@ namespace Akka.Persistence.Azure.Journal
         {
             get
             {
-                if (_tableStorage_DoNotUseDirectly == null)
+                if (!_initialized.Value)
                     throw new Exception("Table storage has not been initialized yet. PreStart() has not been invoked");
-                return _tableStorage_DoNotUseDirectly;
+                return TableServiceClient.GetTableClient(_settings.TableName);
             }
         }
 
@@ -111,6 +96,23 @@ namespace Akka.Persistence.Azure.Journal
 
         protected bool HasTagSubscribers => _tagSubscribers.Count != 0;
 
+        private TableServiceClient TableServiceClient
+        {
+            get
+            {
+                if (_settings.Development)
+                    return new TableServiceClient(connectionString: "UseDevelopmentStorage=true");
+                
+                // Use TokenCredential if both ServiceUri and TokenCredential are populated in the settings 
+                return _settings.ServiceUri != null && _settings.AzureCredential != null
+                    ? new TableServiceClient(
+                        endpoint: _settings.ServiceUri,
+                        tokenCredential: _settings.AzureCredential,
+                        options: _settings.TableClientOptions)
+                    : new TableServiceClient(connectionString: _settings.ConnectionString);
+            }
+        }
+        
         public override async Task<long> ReadHighestSequenceNrAsync(
             string persistenceId,
             long fromSequenceNr)
@@ -263,8 +265,7 @@ namespace Akka.Persistence.Azure.Journal
         {
             _log.Debug("Initializing Azure Table Storage...");
 
-            InitCloudStorage(5, _shutdownCts.Token)
-                .ConfigureAwait(false).GetAwaiter().GetResult();
+            InitCloudStorage(5, _shutdownCts.Token).GetAwaiter().GetResult();
 
             _log.Debug("Successfully started Azure Table Storage!");
 
@@ -620,7 +621,7 @@ namespace Akka.Persistence.Azure.Journal
         {
             try
             {
-                var tableClient = _tableServiceClient.GetTableClient(_settings.TableName);
+                var tableClient = TableServiceClient.GetTableClient(_settings.TableName);
                 
                 var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
                 cts.CancelAfter(_settings.ConnectTimeout);
@@ -639,8 +640,7 @@ namespace Akka.Persistence.Azure.Journal
                         }
                         
                         _log.Info("Successfully connected to existing table", _settings.TableName);
-
-                        _tableStorage_DoNotUseDirectly = tableClient;
+                        _initialized.CompareAndSet(false, true);
                         return;
                     }
                     
@@ -648,7 +648,8 @@ namespace Akka.Persistence.Azure.Journal
                         _log.Info("Created Azure Cloud Table", _settings.TableName);
                     else
                         _log.Info("Successfully connected to existing table", _settings.TableName);
-                    _tableStorage_DoNotUseDirectly = tableClient;
+
+                    _initialized.CompareAndSet(false, true);
                 }
             }
             catch (Exception ex)
@@ -667,7 +668,7 @@ namespace Akka.Persistence.Azure.Journal
 
         private async Task<bool> IsTableExist(string name, CancellationToken cancellationToken)
         {
-            var tables = await _tableServiceClient.QueryAsync(t => t.Name == name, cancellationToken: cancellationToken)
+            var tables = await TableServiceClient.QueryAsync(t => t.Name == name, cancellationToken: cancellationToken)
                 .ToListAsync(cancellationToken)
                 .ConfigureAwait(false);
             return tables.Count > 0;

--- a/src/Akka.Persistence.Azure/Snapshot/AzureBlobSnapshotStore.cs
+++ b/src/Akka.Persistence.Azure/Snapshot/AzureBlobSnapshotStore.cs
@@ -302,9 +302,10 @@ namespace Akka.Persistence.Azure.Snapshot
                     .Where(x => FilterBlobTimestamp(criteria, x));
 
                 var deleteTasks = new List<Task>();
+                var container = Container;
                 await foreach (var blob in filtered.WithCancellation(cts.Token))
                 {
-                    var blobClient = Container.GetBlobClient(blob.Name);
+                    var blobClient = container.GetBlobClient(blob.Name);
                     deleteTasks.Add(blobClient.DeleteIfExistsAsync(cancellationToken: cts.Token));
                 }
 

--- a/src/Akka.Persistence.Azure/Snapshot/AzureBlobSnapshotStore.cs
+++ b/src/Akka.Persistence.Azure/Snapshot/AzureBlobSnapshotStore.cs
@@ -15,6 +15,7 @@ using Akka.Configuration;
 using Akka.Event;
 using Akka.Persistence.Azure.Util;
 using Akka.Persistence.Snapshot;
+using Akka.Util;
 using Akka.Util.Internal;
 using Azure;
 using Azure.Storage.Blobs;
@@ -42,13 +43,12 @@ namespace Akka.Persistence.Azure.Snapshot
         private const string TimeStampMetaDataKey = "Timestamp";
         private const string SeqNoMetaDataKey = "SeqNo";
 
-        private readonly Lazy<BlobContainerClient> _containerClient;
         private readonly ILoggingAdapter _log = Context.GetLogger();
         private readonly SerializationHelper _serialization;
         private readonly AzureBlobSnapshotStoreSettings _settings;
-        private readonly BlobServiceClient _serviceClient;
 
         private readonly CancellationTokenSource _shutdownCts;
+        private AtomicBoolean _initialized = new();
 
         public AzureBlobSnapshotStore(Config config = null)
         {
@@ -70,32 +70,40 @@ namespace Akka.Persistence.Azure.Snapshot
                     _settings = setup.Value.Apply(_settings);
             }
             
-            if (_settings.Development)
+            _shutdownCts = new CancellationTokenSource();
+        }
+
+        public BlobContainerClient Container
+        {
+            get
             {
-                _serviceClient = new BlobServiceClient(connectionString: "UseDevelopmentStorage=true");
+                if (!_initialized.Value)
+                    throw new Exception("Blob storage has not been initialized yet. PreStart() has not been invoked");
+                return BlobServiceClient.GetBlobContainerClient(_settings.ContainerName);
             }
-            else
+        }
+
+        private BlobServiceClient BlobServiceClient
+        {
+            get
             {
-                _serviceClient = _settings.ServiceUri != null && _settings.AzureCredential != null
-                    ? _serviceClient = new BlobServiceClient(
+                if (_settings.Development)
+                    return new BlobServiceClient(connectionString: "UseDevelopmentStorage=true");
+                
+                return _settings.ServiceUri != null && _settings.AzureCredential != null
+                    ? new BlobServiceClient(
                         serviceUri: _settings.ServiceUri, 
                         credential: _settings.AzureCredential,
                         options: _settings.BlobClientOptions)
-                    : _serviceClient = new BlobServiceClient(connectionString: _settings.ConnectionString);
+                    : new BlobServiceClient(connectionString: _settings.ConnectionString);
             }
-
-            _shutdownCts = new CancellationTokenSource();
-            _containerClient = new Lazy<BlobContainerClient>(() => 
-                InitCloudStorage(5, _shutdownCts.Token).GetAwaiter().GetResult());
         }
 
-        public BlobContainerClient Container => _containerClient.Value;
-
-        private async Task<BlobContainerClient> InitCloudStorage(int remainingTries, CancellationToken cancellationToken)
+        private async Task InitCloudStorage(int remainingTries, CancellationToken cancellationToken)
         {
             try
             {
-                var blobClient = _serviceClient.GetBlobContainerClient(_settings.ContainerName);
+                var blobClient = BlobServiceClient.GetBlobContainerClient(_settings.ContainerName);
 
                 var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
                 cts.CancelAfter(_settings.ConnectTimeout);
@@ -115,7 +123,8 @@ namespace Akka.Persistence.Azure.Snapshot
                         
                         _log.Info("Successfully connected to existing container {0}", _settings.ContainerName);
                         
-                        return blobClient;
+                        _initialized.CompareAndSet(false, true);
+                        return;
                     }
                 
                     if (await blobClient.ExistsAsync(cts.Token))
@@ -136,7 +145,7 @@ namespace Akka.Persistence.Azure.Snapshot
                         }
                     }
 
-                    return blobClient;
+                    _initialized.CompareAndSet(false, true);
                 }
             }
             catch (Exception ex)
@@ -148,7 +157,7 @@ namespace Akka.Persistence.Azure.Snapshot
                 if (cancellationToken.IsCancellationRequested)
                     throw;
                 
-                return await InitCloudStorage(remainingTries - 1, cancellationToken);
+                await InitCloudStorage(remainingTries - 1, cancellationToken);
             }
         }
 
@@ -156,8 +165,7 @@ namespace Akka.Persistence.Azure.Snapshot
         {
             _log.Debug("Initializing Azure Container Storage...");
 
-            // forces loading of the value
-            var name = Container.Name;
+            InitCloudStorage(5, _shutdownCts.Token).GetAwaiter().GetResult();
 
             _log.Debug("Successfully started Azure Container Storage!");
 


### PR DESCRIPTION
## Issue

A user reported that `DefaultAzureCredential` might be cached inside the journal and snapshot classes, causing them to consistently fail if the credential was rejected on the first REST call.

## Changes

Make sure that all Azure clients are created on demand. Azure client classes are thin REST clients, using cached clients might not be the best solution because the internal states inside the client should not be persisted between use.