### PR TITLE
Add option to inject arbitrary service client into journal/snapshot using factory functions

### DIFF
--- a/src/Akka.Persistence.Azure.Hosting/AzureBlobSnapshotOptions.cs
+++ b/src/Akka.Persistence.Azure.Hosting/AzureBlobSnapshotOptions.cs
@@ -93,6 +93,12 @@ namespace Akka.Persistence.Azure.Hosting
         /// </summary>
         public BlobClientOptions? BlobClientOptions { get; set; }
 
+        /// <summary>
+        ///     The Azure <see cref="BlobServiceClientFactory"/> to be used by the journal.
+        ///     When set, this will override any connection string or token credential in this setup.
+        /// </summary>
+        public Func<BlobServiceClient>? BlobServiceClientFactory { get; set; }
+        
         protected override StringBuilder Build(StringBuilder sb)
         {
             if (ConnectionString is { })
@@ -139,6 +145,7 @@ namespace Akka.Persistence.Azure.Hosting
             setup.ServiceUri = ServiceUri;
             setup.AzureCredential = AzureCredential;
             setup.BlobClientOptions = BlobClientOptions;
+            setup.BlobServiceClientFactory = BlobServiceClientFactory;
         }
     }
 }

--- a/src/Akka.Persistence.Azure.Hosting/AzurePersistenceExtensions.cs
+++ b/src/Akka.Persistence.Azure.Hosting/AzurePersistenceExtensions.cs
@@ -12,7 +12,6 @@ using Akka.Persistence.Azure.Snapshot;
 using Akka.Persistence.Hosting;
 using Azure.Core;
 using Azure.Data.Tables;
-using Azure.Identity;
 using Azure.Storage.Blobs;
 
 namespace Akka.Persistence.Azure.Hosting
@@ -25,6 +24,58 @@ namespace Akka.Persistence.Azure.Hosting
         public const string DefaultTableName = "AkkaPersistenceDefaultTable";
         public const string DefaultBlobContainerName = "akka-persistence-default-container";
         
+        /// <summary>
+        ///     Add an AzureTableStorage journal Akka.Persistence implementations for a given <see cref="ActorSystem"/>.
+        /// </summary>
+        /// <param name="builder">
+        ///     The <see cref="AkkaConfigurationBuilder"/> builder instance being configured.
+        /// </param>
+        /// <param name="tableServiceClientFactory">
+        ///     The Azure <see cref="TableServiceClient"/> to be used by the journal.
+        /// </param>
+        /// <param name="autoInitialize">
+        ///     Automatically create the Table Storage table and Storage blob if no existing table is found
+        /// </param>
+        /// <param name="tableName">
+        ///     The Azure table we'll be connecting to.
+        /// </param>
+        /// <param name="eventAdapterConfigurator">
+        ///     A delegate that can be used to configure an <see cref="AkkaPersistenceJournalBuilder"/> instance
+        ///     to set up event adapters.
+        /// </param>
+        /// <param name="isDefault">
+        ///     Indicates if this journal instance is the default persistence journal for the <see cref="ActorSystem"/>
+        /// </param>
+        /// <param name="identifier">
+        ///     The journal identifier, defaults to "azure-table"
+        /// </param>
+        /// <returns>
+        ///     The same <see cref="AkkaConfigurationBuilder"/> instance originally passed in.
+        /// </returns>        
+        public static AkkaConfigurationBuilder WithAzureTableJournal(this AkkaConfigurationBuilder builder,
+            Func<TableServiceClient> tableServiceClientFactory,
+            bool autoInitialize = true,
+            string tableName = DefaultTableName,
+            Action<AkkaPersistenceJournalBuilder>? eventAdapterConfigurator = null,
+            bool isDefault = true,
+            string identifier = "azure-table")
+        {
+            if (tableServiceClientFactory is null)
+                throw new ArgumentNullException(nameof(tableServiceClientFactory));
+            
+            var options = new AzureTableStorageJournalOptions(isDefault, identifier)
+            {
+                TableServiceClientFactory = tableServiceClientFactory,
+                AutoInitialize = autoInitialize,
+                TableName = tableName
+            };
+            
+            if (eventAdapterConfigurator != null)
+                eventAdapterConfigurator(options.Adapters);
+            
+            return WithAzureTableJournal(builder, options);
+        }
+
         /// <summary>
         ///     Add an AzureTableStorage journal Akka.Persistence implementations for a given <see cref="ActorSystem"/>.
         /// </summary>
@@ -274,6 +325,51 @@ namespace Akka.Persistence.Azure.Hosting
             return builder;
         }
         
+        /// <summary>
+        ///     Add an AzureBlobStorage snapshot-store Akka.Persistence implementations for a given <see cref="ActorSystem"/>.
+        /// </summary>
+        /// <param name="builder">
+        ///     The <see cref="AkkaConfigurationBuilder"/> builder instance being configured.
+        /// </param>
+        /// <param name="blobServiceClientFactory">
+        ///     The Azure <see cref="BlobServiceClient"/> to be used by the snapshot store.
+        /// </param>
+        /// <param name="autoInitialize">
+        ///     Automatically create the Table Storage table and Storage blob if no existing table is found
+        /// </param>
+        /// <param name="containerName">
+        ///     The table of the container we'll be using to serialize these blobs.
+        /// </param>
+        /// <param name="isDefault">
+        ///     Indicates if this journal instance is the default persistence journal for the <see cref="ActorSystem"/>
+        /// </param>
+        /// <param name="identifier">
+        ///     The journal identifier, defaults to "azure-blob-store"
+        /// </param>
+        /// <returns>
+        ///     The same <see cref="AkkaConfigurationBuilder"/> instance originally passed in.
+        /// </returns>
+        public static AkkaConfigurationBuilder WithAzureBlobsSnapshotStore(
+            this AkkaConfigurationBuilder builder,
+            Func<BlobServiceClient> blobServiceClientFactory,
+            bool autoInitialize = true,
+            string containerName = DefaultBlobContainerName,
+            bool isDefault = true,
+            string identifier = "azure-blob-store")
+        {
+            if (blobServiceClientFactory is null)
+                throw new ArgumentNullException(nameof(blobServiceClientFactory));
+            
+            var options = new AzureBlobSnapshotOptions(isDefault, identifier)
+            {
+                BlobServiceClientFactory = blobServiceClientFactory,
+                AutoInitialize = autoInitialize,
+                ContainerName = containerName
+            };
+            
+            return WithAzureBlobsSnapshotStore(builder, options);
+        }
+
         /// <summary>
         ///     Add an AzureBlobStorage snapshot-store Akka.Persistence implementations for a given <see cref="ActorSystem"/>.
         /// </summary>
@@ -592,6 +688,50 @@ namespace Akka.Persistence.Azure.Hosting
         {
             builder.WithAzureTableJournal(tableStorageServiceUri, defaultAzureCredential, tableClientOptions, autoInitialize, tableName, eventAdapterConfigurator);
             builder.WithAzureBlobsSnapshotStore(blobStorageServiceUri, defaultAzureCredential, blobClientOptions, autoInitialize, containerName);
+
+            return builder;
+        }
+
+        /// <summary>
+        ///     Adds both AzureTableStorage journal and AzureBlobStorage snapshot-store as the default Akka.Persistence
+        ///     implementations for a given <see cref="ActorSystem"/>.
+        /// </summary>
+        /// <param name="builder">
+        ///     The <see cref="AkkaConfigurationBuilder"/> builder instance being configured.
+        /// </param>
+        /// <param name="tableServiceClientFactory">
+        ///     The Azure <see cref="TableServiceClient"/> to be used by the journal.
+        /// </param>
+        /// <param name="blobServiceClientFactory">
+        ///     The Azure <see cref="BlobServiceClient"/> to be used by the snapshot store.
+        /// </param>
+        /// <param name="autoInitialize">
+        ///     Automatically create the Table Storage table and Storage blob if no existing table is found
+        /// </param>
+        /// <param name="containerName">
+        ///     The table of the container we'll be using to serialize these blobs.
+        /// </param>
+        /// <param name="tableName">
+        ///     The Azure table we'll be connecting to.
+        /// </param>
+        /// <param name="eventAdapterConfigurator">
+        ///     A delegate that can be used to configure an <see cref="AkkaPersistenceJournalBuilder"/> instance
+        ///     to set up event adapters.
+        /// </param>
+        /// <returns>
+        ///     The same <see cref="AkkaConfigurationBuilder"/> instance originally passed in.
+        /// </returns>
+        public static AkkaConfigurationBuilder WithAzurePersistence(
+            this AkkaConfigurationBuilder builder,
+            Func<TableServiceClient> tableServiceClientFactory,
+            Func<BlobServiceClient> blobServiceClientFactory,
+            bool autoInitialize = true,
+            string containerName = DefaultBlobContainerName,
+            string tableName = DefaultTableName,
+            Action<AkkaPersistenceJournalBuilder>? eventAdapterConfigurator = null)
+        {
+            builder.WithAzureTableJournal(tableServiceClientFactory, autoInitialize, tableName, eventAdapterConfigurator);
+            builder.WithAzureBlobsSnapshotStore(blobServiceClientFactory, autoInitialize, containerName);
 
             return builder;
         }

--- a/src/Akka.Persistence.Azure.Hosting/AzureTableStorageJournalOptions.cs
+++ b/src/Akka.Persistence.Azure.Hosting/AzureTableStorageJournalOptions.cs
@@ -83,6 +83,12 @@ namespace Akka.Persistence.Azure.Hosting
         /// </summary>
         public TableClientOptions? TableClientOptions { get; set; }
 
+        /// <summary>
+        ///     The Azure <see cref="TableServiceClientFactory"/> to be used by the journal.
+        ///     When set, this will override any connection string or token credential in this setup.
+        /// </summary>
+        public Func<TableServiceClient>? TableServiceClientFactory { get; set; }
+        
         protected override StringBuilder Build(StringBuilder sb)
         {
             if(ConnectionString is { })
@@ -130,6 +136,7 @@ namespace Akka.Persistence.Azure.Hosting
             setup.ServiceUri = ServiceUri;
             setup.AzureCredential = AzureCredential;
             setup.TableClientOptions = TableClientOptions;
+            setup.TableServiceClientFactory = TableServiceClientFactory;
         }        
     }
 }

--- a/src/Akka.Persistence.Azure.Tests/AzurePersistenceConfigSpec.cs
+++ b/src/Akka.Persistence.Azure.Tests/AzurePersistenceConfigSpec.cs
@@ -17,6 +17,7 @@ using Azure.Storage.Blobs.Models;
 using FluentAssertions;
 using FluentAssertions.Extensions;
 using Xunit;
+#pragma warning disable CS0618 // Type or member is obsolete
 
 namespace Akka.Persistence.Azure.Tests
 {
@@ -54,6 +55,7 @@ namespace Akka.Persistence.Azure.Tests
             settings.ServiceUri.Should().BeNull();
             settings.AzureCredential.Should().BeNull();
             settings.BlobClientOptions.Should().BeNull();
+            settings.BlobServiceClientFactory.Should().BeNull();
         }
         
         [Fact(DisplayName = "AzureBlobSnapshotStoreSettings With overrides should override default values")]
@@ -61,6 +63,7 @@ namespace Akka.Persistence.Azure.Tests
         {
             var uri = new Uri("https://whatever.com");
             var credentials = new DefaultAzureCredential();
+            var client = new BlobServiceClient(uri, credentials);
             var options = new BlobClientOptions();
             var settings = DefaultSnapshotSettings
                     .WithConnectionString("abc")
@@ -71,19 +74,22 @@ namespace Akka.Persistence.Azure.Tests
                     .WithDevelopment(true)
                     .WithAutoInitialize(false)
                     .WithContainerPublicAccessType(PublicAccessType.Blob)
-                    .WithAzureCredential(uri, credentials, options);
+                    .WithAzureCredential(uri, credentials, options)
+                    .WithBlobServiceClientFactory(() => client);
 
             settings.ConnectionString.Should().Be("abc");
             settings.ContainerName.Should().Be("bcd");
             settings.ConnectTimeout.Should().Be(1.Seconds());
             settings.RequestTimeout.Should().Be(2.Seconds());
             settings.VerboseLogging.Should().BeTrue();
-            settings.Development.Should().BeTrue();
+            settings.Development.Should().BeFalse();
             settings.AutoInitialize.Should().BeFalse();
             settings.ContainerPublicAccessType.Should().Be(PublicAccessType.Blob);
             settings.ServiceUri.Should().Be(uri);
             settings.AzureCredential.Should().Be(credentials);
             settings.BlobClientOptions.Should().Be(options);
+            settings.BlobServiceClientFactory.Should().NotBeNull();
+            settings.BlobServiceClientFactory!.Invoke().Should().Be(client);
         }
 
         [Fact(DisplayName = "AzureBlobSnapshotStoreSetup should override settings values")]
@@ -91,6 +97,7 @@ namespace Akka.Persistence.Azure.Tests
         {
             var uri = new Uri("https://whatever.com");
             var credentials = new DefaultAzureCredential();
+            var client = new BlobServiceClient(uri, credentials);
             var options = new BlobClientOptions();
             var setup = new AzureBlobSnapshotSetup
             {
@@ -104,7 +111,8 @@ namespace Akka.Persistence.Azure.Tests
                 ContainerPublicAccessType = PublicAccessType.Blob,
                 ServiceUri = uri,
                 AzureCredential = credentials,
-                BlobClientOptions = options
+                BlobClientOptions = options,
+                BlobServiceClientFactory = () => client,
             };
 
             var settings = setup.Apply(DefaultSnapshotSettings);
@@ -114,12 +122,14 @@ namespace Akka.Persistence.Azure.Tests
             settings.ConnectTimeout.Should().Be(1.Seconds());
             settings.RequestTimeout.Should().Be(2.Seconds());
             settings.VerboseLogging.Should().BeTrue();
-            settings.Development.Should().BeTrue();
+            settings.Development.Should().BeFalse();
             settings.AutoInitialize.Should().BeFalse();
             settings.ContainerPublicAccessType.Should().Be(PublicAccessType.Blob);
             settings.ServiceUri.Should().Be(uri);
             settings.AzureCredential.Should().Be(credentials);
             settings.BlobClientOptions.Should().Be(options);
+            settings.BlobServiceClientFactory.Should().NotBeNull();
+            settings.BlobServiceClientFactory!.Invoke().Should().Be(client);
         }
 
         [Fact(DisplayName = "AzureBlobSnapshotStoreOptions should override settings values")]
@@ -127,6 +137,7 @@ namespace Akka.Persistence.Azure.Tests
         {
             var uri = new Uri("https://whatever.com");
             var credentials = new DefaultAzureCredential();
+            var client = new BlobServiceClient(uri, credentials);
             var blobOptions = new BlobClientOptions();
             var options = new AzureBlobSnapshotOptions(false, "abcd")
             {
@@ -140,7 +151,8 @@ namespace Akka.Persistence.Azure.Tests
                 ContainerPublicAccessType = PublicAccessType.Blob,
                 ServiceUri = uri,
                 AzureCredential = credentials,
-                BlobClientOptions = blobOptions
+                BlobClientOptions = blobOptions,
+                BlobServiceClientFactory = () => client
             };
 
             var settings = AzureBlobSnapshotStoreSettings.Create(
@@ -155,12 +167,14 @@ namespace Akka.Persistence.Azure.Tests
             settings.ConnectTimeout.Should().Be(1.Seconds());
             settings.RequestTimeout.Should().Be(2.Seconds());
             settings.VerboseLogging.Should().BeTrue();
-            settings.Development.Should().BeTrue();
+            settings.Development.Should().BeFalse();
             settings.AutoInitialize.Should().BeFalse();
             settings.ContainerPublicAccessType.Should().Be(PublicAccessType.Blob);
             settings.ServiceUri.Should().Be(uri);
             settings.AzureCredential.Should().Be(credentials);
             settings.BlobClientOptions.Should().Be(blobOptions);
+            settings.BlobServiceClientFactory.Should().NotBeNull();
+            settings.BlobServiceClientFactory!.Invoke().Should().Be(client);
         }
 
         [Fact]
@@ -178,6 +192,7 @@ namespace Akka.Persistence.Azure.Tests
             settings.ServiceUri.Should().BeNull();
             settings.AzureCredential.Should().BeNull();
             settings.TableClientOptions.Should().BeNull();
+            settings.TableServiceClientFactory.Should().BeNull();
         }
 
         [Fact(DisplayName = "AzureTableStorageJournalSettings With overrides should override default values")]
@@ -185,6 +200,7 @@ namespace Akka.Persistence.Azure.Tests
         {
             var uri = new Uri("https://whatever.com");
             var credentials = new DefaultAzureCredential();
+            var client = new TableServiceClient(uri, credentials);
             var options = new TableClientOptions();
             var settings = DefaultJournalSettings
                     .WithConnectionString("abc")
@@ -194,18 +210,21 @@ namespace Akka.Persistence.Azure.Tests
                     .WithVerboseLogging(true)
                     .WithDevelopment(true)
                     .WithAutoInitialize(false)
-                    .WithAzureCredential(uri, credentials, options);
+                    .WithAzureCredential(uri, credentials, options)
+                    .WithTableServiceClientFactory(() => client);
 
             settings.ConnectionString.Should().Be("abc");
             settings.TableName.Should().Be("bcd");
             settings.ConnectTimeout.Should().Be(1.Seconds());
             settings.RequestTimeout.Should().Be(2.Seconds());
             settings.VerboseLogging.Should().BeTrue();
-            settings.Development.Should().BeTrue();
+            settings.Development.Should().BeFalse();
             settings.AutoInitialize.Should().BeFalse();
             settings.ServiceUri.Should().Be(uri);
             settings.AzureCredential.Should().Be(credentials);
             settings.TableClientOptions.Should().Be(options);
+            settings.TableServiceClientFactory.Should().NotBeNull();
+            settings.TableServiceClientFactory!.Invoke().Should().Be(client);
         }
 
         [Fact(DisplayName = "AzureTableStorageJournalSetup should override settings values")]
@@ -213,6 +232,7 @@ namespace Akka.Persistence.Azure.Tests
         {
             var uri = new Uri("https://whatever.com");
             var credentials = new DefaultAzureCredential();
+            var client = new TableServiceClient(uri, credentials);
             var options = new TableClientOptions();
             var setup = new AzureTableStorageJournalSetup
             {
@@ -225,7 +245,8 @@ namespace Akka.Persistence.Azure.Tests
                 AutoInitialize = false,
                 ServiceUri = uri,
                 AzureCredential = credentials,
-                TableClientOptions = options
+                TableClientOptions = options,
+                TableServiceClientFactory = () => client
             };
 
             var settings = setup.Apply(DefaultJournalSettings);
@@ -235,11 +256,13 @@ namespace Akka.Persistence.Azure.Tests
             settings.ConnectTimeout.Should().Be(1.Seconds());
             settings.RequestTimeout.Should().Be(2.Seconds());
             settings.VerboseLogging.Should().BeTrue();
-            settings.Development.Should().BeTrue();
+            settings.Development.Should().BeFalse();
             settings.AutoInitialize.Should().BeFalse();
             settings.ServiceUri.Should().Be(uri);
             settings.AzureCredential.Should().Be(credentials);
             settings.TableClientOptions.Should().Be(options);
+            settings.TableServiceClientFactory.Should().NotBeNull();
+            settings.TableServiceClientFactory!.Invoke().Should().Be(client);
         }
         
         [Fact(DisplayName = "AzureTableStorageJournalOptions should override settings values")]
@@ -247,6 +270,7 @@ namespace Akka.Persistence.Azure.Tests
         {
             var uri = new Uri("https://whatever.com");
             var credentials = new DefaultAzureCredential();
+            var client = new TableServiceClient(uri, credentials);
             var clientOptions = new TableClientOptions();
             var options = new AzureTableStorageJournalOptions(false, "abcd")
             {
@@ -259,7 +283,8 @@ namespace Akka.Persistence.Azure.Tests
                 AutoInitialize = false,
                 ServiceUri = uri,
                 AzureCredential = credentials,
-                TableClientOptions = clientOptions
+                TableClientOptions = clientOptions,
+                TableServiceClientFactory = () => client
             };
 
             var settings = AzureTableStorageJournalSettings.Create(
@@ -274,11 +299,13 @@ namespace Akka.Persistence.Azure.Tests
             settings.ConnectTimeout.Should().Be(1.Seconds());
             settings.RequestTimeout.Should().Be(2.Seconds());
             settings.VerboseLogging.Should().BeTrue();
-            settings.Development.Should().BeTrue();
+            settings.Development.Should().BeFalse();
             settings.AutoInitialize.Should().BeFalse();
             settings.ServiceUri.Should().Be(uri);
             settings.AzureCredential.Should().Be(credentials);
             settings.TableClientOptions.Should().Be(clientOptions);
+            settings.TableServiceClientFactory.Should().NotBeNull();
+            settings.TableServiceClientFactory!.Invoke().Should().Be(client);
         }
         
         [Theory]

--- a/src/Akka.Persistence.Azure/Journal/AzureTableStorageJournal.cs
+++ b/src/Akka.Persistence.Azure/Journal/AzureTableStorageJournal.cs
@@ -18,10 +18,12 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Akka.Configuration;
+using Akka.Util;
 using Azure;
 using Azure.Data.Tables;
 using Debug = System.Diagnostics.Debug;
 
+#nullable enable
 namespace Akka.Persistence.Azure.Journal
 {
     /// <inheritdoc />
@@ -52,11 +54,10 @@ namespace Akka.Persistence.Azure.Journal
         private readonly SerializationHelper _serialization;
         private readonly AzureTableStorageJournalSettings _settings;
         private readonly TableServiceClient _tableServiceClient;
-        private TableClient _tableStorage_DoNotUseDirectly;
         private readonly Dictionary<string, ISet<IActorRef>> _tagSubscribers = new Dictionary<string, ISet<IActorRef>>();
         private readonly CancellationTokenSource _shutdownCts;
 
-        public AzureTableStorageJournal(Config config = null)
+        public AzureTableStorageJournal(Config? config = null)
         {
             _settings = config is null ? 
                 AzurePersistence.Get(Context.System).TableSettings :
@@ -70,16 +71,16 @@ namespace Akka.Persistence.Azure.Journal
             if (multiSetup.HasValue)
             {
                 var journalId = Self.Path.Name.SplitDottedPathHonouringQuotes().Last();
-                setup = multiSetup.Value.Get(journalId);
+                setup = Option<AzureTableStorageJournalSetup>.Create(multiSetup.Value!.Get(journalId)!);
                 if(setup.HasValue)
                     _settings = setup.Value.Apply(_settings);
             }
             
             _serialization = new SerializationHelper(Context.System);
 
-            if (_settings.Development)
+            if (_settings.TableServiceClientFactory != null)
             {
-                _tableServiceClient = new TableServiceClient(connectionString: "UseDevelopmentStorage=true");
+                _tableServiceClient = _settings.TableServiceClientFactory.Invoke();
             }
             else
             {
@@ -89,21 +90,17 @@ namespace Akka.Persistence.Azure.Journal
                         endpoint: _settings.ServiceUri,
                         tokenCredential: _settings.AzureCredential,
                         options: _settings.TableClientOptions)
-                    : new TableServiceClient(connectionString: _settings.ConnectionString);
+                    : !string.IsNullOrWhiteSpace(_settings.ConnectionString) 
+                        ? new TableServiceClient(connectionString: _settings.ConnectionString)
+                        : throw new ConfigurationException(
+                            "No connection method configured. ConnectionString, AzureCredential, or " +
+                            "TableServiceClientFactory must be specified.");
             }
 
             _shutdownCts = new CancellationTokenSource();
         }
 
-        public TableClient Table
-        {
-            get
-            {
-                if (_tableStorage_DoNotUseDirectly == null)
-                    throw new Exception("Table storage has not been initialized yet. PreStart() has not been invoked");
-                return _tableStorage_DoNotUseDirectly;
-            }
-        }
+        public TableClient Table => _tableServiceClient.GetTableClient(_settings.TableName);
 
         protected bool HasAllPersistenceIdSubscribers => _allPersistenceIdSubscribers.Count != 0;
 
@@ -263,8 +260,7 @@ namespace Akka.Persistence.Azure.Journal
         {
             _log.Debug("Initializing Azure Table Storage...");
 
-            InitCloudStorage(5, _shutdownCts.Token)
-                .ConfigureAwait(false).GetAwaiter().GetResult();
+            InitCloudStorage(5, _shutdownCts.Token).GetAwaiter().GetResult();
 
             _log.Debug("Successfully started Azure Table Storage!");
 
@@ -309,12 +305,12 @@ namespace Akka.Persistence.Azure.Journal
             return true;
         }
 
-        protected override async Task<IImmutableList<Exception>> WriteMessagesAsync(IEnumerable<AtomicWrite> atomicWrites)
+        protected override async Task<IImmutableList<Exception?>?> WriteMessagesAsync(IEnumerable<AtomicWrite> atomicWrites)
         {
             try
             {
                 var taggedEntries = new Dictionary<string, List<EventTagEntry>>();
-                var exceptions = new List<Exception>();
+                var exceptions = new List<Exception?>();
                 var highSequenceNumbers = new Dictionary<string, long>();
 
                 using (var currentWrites = atomicWrites.GetEnumerator())
@@ -639,8 +635,6 @@ namespace Akka.Persistence.Azure.Journal
                         }
                         
                         _log.Info("Successfully connected to existing table", _settings.TableName);
-
-                        _tableStorage_DoNotUseDirectly = tableClient;
                         return;
                     }
                     
@@ -648,7 +642,6 @@ namespace Akka.Persistence.Azure.Journal
                         _log.Info("Created Azure Cloud Table", _settings.TableName);
                     else
                         _log.Info("Successfully connected to existing table", _settings.TableName);
-                    _tableStorage_DoNotUseDirectly = tableClient;
                 }
             }
             catch (Exception ex)

--- a/src/Akka.Persistence.Azure/Journal/AzureTableStorageJournalSettings.cs
+++ b/src/Akka.Persistence.Azure/Journal/AzureTableStorageJournalSettings.cs
@@ -11,21 +11,22 @@ using Akka.Configuration;
 using Akka.Persistence.Azure.Util;
 using Azure.Core;
 using Azure.Data.Tables;
-using Azure.Identity;
 
+#nullable enable
 namespace Akka.Persistence.Azure.Journal
 {
     /// <summary>
-    ///     Defines all of the configuration settings used by the `akka.persistence.journal.azure-table` plugin.
+    ///     Defines all the configuration settings used by the `akka.persistence.journal.azure-table` plugin.
     /// </summary>
     public sealed class AzureTableStorageJournalSettings
     {
         public const string JournalConfigPath = "akka.persistence.journal.azure-table";
         private static readonly string[] ReservedTableNames = {"tables"};
         
-        [Obsolete]
+        // ReSharper disable IntroduceOptionalParameters.Global
+        [Obsolete(message:"Use constructor with serviceUri, defaultAzureCredential, tableClientOptions, and tableServiceClientFactory argument instead.")]
         public AzureTableStorageJournalSettings(
-            string connectionString, 
+            string? connectionString, 
             string tableName, 
             TimeSpan connectTimeout,
             TimeSpan requestTimeout, 
@@ -42,20 +43,49 @@ namespace Akka.Persistence.Azure.Journal
                 autoInitialize: autoInitialize,
                 serviceUri: null,
                 defaultAzureCredential: null,
-                tableClientOptions: null)
+                tableClientOptions: null, 
+                tableServiceClientFactory: null)
         { }
             
+        [Obsolete(message:"Use constructor with tableServiceClientFactory argument instead.")]
         public AzureTableStorageJournalSettings(
-            string connectionString, 
+            string? connectionString,
+            string tableName,
+            TimeSpan connectTimeout,
+            TimeSpan requestTimeout,
+            bool verboseLogging,
+            bool development,
+            bool autoInitialize,
+            Uri? serviceUri,
+            TokenCredential? defaultAzureCredential,
+            TableClientOptions? tableClientOptions)
+            : this(
+                connectionString: connectionString,
+                tableName: tableName,
+                connectTimeout: connectTimeout,
+                requestTimeout: requestTimeout,
+                verboseLogging: verboseLogging,
+                development: development,
+                autoInitialize: autoInitialize,
+                serviceUri: serviceUri,
+                defaultAzureCredential: defaultAzureCredential,
+                tableClientOptions: tableClientOptions, 
+                tableServiceClientFactory: null)
+        { }
+        // ReSharper restore IntroduceOptionalParameters.Global
+        
+        public AzureTableStorageJournalSettings(
+            string? connectionString, 
             string tableName, 
             TimeSpan connectTimeout,
             TimeSpan requestTimeout, 
             bool verboseLogging,
             bool development, 
             bool autoInitialize,
-            Uri serviceUri,
-            TokenCredential defaultAzureCredential,
-            TableClientOptions tableClientOptions)
+            Uri? serviceUri,
+            TokenCredential? defaultAzureCredential,
+            TableClientOptions? tableClientOptions,
+            Func<TableServiceClient>? tableServiceClientFactory)
         {
             if(string.IsNullOrWhiteSpace(tableName))
                 throw new ConfigurationException("[AzureTableStorageJournal] Table name is null or empty.");
@@ -73,17 +103,17 @@ namespace Akka.Persistence.Azure.Journal
             ConnectTimeout = connectTimeout;
             RequestTimeout = requestTimeout;
             VerboseLogging = verboseLogging;
-            Development = development;
             AutoInitialize = autoInitialize;
             ServiceUri = serviceUri;
             AzureCredential = defaultAzureCredential;
             TableClientOptions = tableClientOptions;
+            TableServiceClientFactory = tableServiceClientFactory;
         }
 
         /// <summary>
         ///     The connection string for connecting to Windows Azure table storage.
         /// </summary>
-        public string ConnectionString { get; }
+        public string? ConnectionString { get; }
 
         /// <summary>
         ///     The table of the table we'll be connecting to.
@@ -110,7 +140,8 @@ namespace Akka.Persistence.Azure.Journal
         ///     <see cref="ConnectionString"/> will be ignored, replaced with "UseDevelopmentStorage=true" for local
         ///     connection to Azurite.
         /// </summary>
-        public bool Development { get; }
+        [Obsolete(message: "The Development property is not being applied anymore. Please set ConnectionString to 'UseDevelopmentStorage=true' instead.")]
+        public bool Development => false;
         
         /// <summary>
         ///     Automatically create the Table Storage table if no existing table is found
@@ -121,24 +152,30 @@ namespace Akka.Persistence.Azure.Journal
         ///     A <see cref="Uri"/> referencing the Azure Table Storage service.
         ///     This is likely to be similar to "https://{account_name}.table.core.windows.net".
         /// </summary>
-        public Uri ServiceUri { get; }
+        public Uri? ServiceUri { get; }
 
         /// <summary>
         ///     The <see cref="TokenCredential"/> used to sign API requests.
         /// </summary>
         [Obsolete(message: "Use AzureCredential instead")]
-        public TokenCredential DefaultAzureCredential => AzureCredential;
+        public TokenCredential? DefaultAzureCredential => AzureCredential;
 
         /// <summary>
         ///     The <see cref="TokenCredential"/> used to sign API requests.
         /// </summary>
-        public TokenCredential AzureCredential { get; }
+        public TokenCredential? AzureCredential { get; }
 
         /// <summary>
         ///     Optional client options that define the transport pipeline policies for authentication,
         ///     retries, etc., that are applied to every request.
         /// </summary>
-        public TableClientOptions TableClientOptions { get; }
+        public TableClientOptions? TableClientOptions { get; }
+        
+        /// <summary>
+        ///     A factory function that returns an instance of Azure <see cref="TableServiceClient"/> to be used by the journal.
+        ///     When set, this will override any connection string or token credential in this setup.
+        /// </summary>
+        public Func<TableServiceClient>? TableServiceClientFactory { get; }
 
         public AzureTableStorageJournalSettings WithConnectionString(string connectionString)
             => Copy(connectionString: connectionString);
@@ -150,41 +187,44 @@ namespace Akka.Persistence.Azure.Journal
             => Copy(requestTimeout: requestTimeout);
         public AzureTableStorageJournalSettings WithVerboseLogging(bool verboseLogging)
             => Copy(verboseLogging: verboseLogging);
-        public AzureTableStorageJournalSettings WithDevelopment(bool development)
-            => Copy(development: development);
+        [Obsolete(message: "The Development property is not being applied anymore. Please set ConnectionString to 'UseDevelopmentStorage=true' instead.")]
+        public AzureTableStorageJournalSettings WithDevelopment(bool development) => this;
         public AzureTableStorageJournalSettings WithAutoInitialize(bool autoInitialize)
             => Copy(autoInitialize: autoInitialize);
         public AzureTableStorageJournalSettings WithAzureCredential(
             Uri serviceUri,
             TokenCredential defaultAzureCredential,
-            TableClientOptions tableClientOptions = null)
+            TableClientOptions? tableClientOptions = null)
             => Copy(
                 serviceUri: serviceUri,
                 azureCredential: defaultAzureCredential,
                 tableClientOptions: tableClientOptions);
+        public AzureTableStorageJournalSettings WithTableServiceClientFactory(Func<TableServiceClient> tableServiceClientFactory)
+            => Copy(tableServiceClientFactory: tableServiceClientFactory);
         
         private AzureTableStorageJournalSettings Copy(
-            string connectionString = null,
-            string tableName = null,
+            string? connectionString = null,
+            string? tableName = null,
             TimeSpan? connectTimeout = null,
             TimeSpan? requestTimeout = null,
             bool? verboseLogging = null,
-            bool? development = null,
             bool? autoInitialize = null,
-            Uri serviceUri = null,
-            TokenCredential azureCredential = null,
-            TableClientOptions tableClientOptions = null)
+            Uri? serviceUri = null,
+            TokenCredential? azureCredential = null,
+            TableClientOptions? tableClientOptions = null,
+            Func<TableServiceClient>? tableServiceClientFactory = null)
             => new AzureTableStorageJournalSettings(
                 connectionString: connectionString ?? ConnectionString,
                 tableName: tableName ?? TableName,
                 connectTimeout: connectTimeout ?? ConnectTimeout,
                 requestTimeout: requestTimeout ?? RequestTimeout,
                 verboseLogging: verboseLogging ?? VerboseLogging,
-                development: development ?? Development,
+                development: false,
                 autoInitialize: autoInitialize ?? AutoInitialize,
                 serviceUri: serviceUri ?? ServiceUri,
                 defaultAzureCredential: azureCredential ?? AzureCredential,
-                tableClientOptions: tableClientOptions ?? TableClientOptions);
+                tableClientOptions: tableClientOptions ?? TableClientOptions,
+                tableServiceClientFactory: tableServiceClientFactory);
 
         /// <summary>
         ///     Creates an <see cref="AzureTableStorageJournalSettings" /> instance using the
@@ -230,7 +270,8 @@ namespace Akka.Persistence.Azure.Journal
                 autoInitialize: autoInitialize,
                 serviceUri: null,
                 defaultAzureCredential: null,
-                tableClientOptions: null);
+                tableClientOptions: null,
+                tableServiceClientFactory: null);
         }
     }
 }

--- a/src/Akka.Persistence.Azure/Journal/AzureTableStorageJournalSetup.cs
+++ b/src/Akka.Persistence.Azure/Journal/AzureTableStorageJournalSetup.cs
@@ -9,7 +9,6 @@ using System.Collections.Generic;
 using Akka.Actor.Setup;
 using Azure.Core;
 using Azure.Data.Tables;
-using Azure.Identity;
 
 #nullable enable
 namespace Akka.Persistence.Azure.Journal
@@ -28,6 +27,45 @@ namespace Akka.Persistence.Azure.Journal
     
     public sealed class AzureTableStorageJournalSetup : Setup
     {
+        /// <summary>
+        ///     Create a new <see cref="AzureTableStorageJournalSetup"/>
+        /// </summary>
+        /// <param name="serviceUri">
+        ///     A <see cref="Uri"/> referencing the blob service.
+        ///     This is likely to be similar to "https://{account_name}.blob.core.windows.net".
+        /// </param>
+        /// <param name="defaultAzureCredential">
+        ///     The <see cref="TokenCredential"/> used to sign requests.
+        /// </param>
+        /// <param name="tableClientOptions">
+        ///     Optional client options that define the transport pipeline policies for authentication,
+        ///     retries, etc., that are applied to every request.
+        /// </param>
+        /// <returns>A new <see cref="AzureTableStorageJournalSetup"/> instance</returns>
+        public static AzureTableStorageJournalSetup Create(
+            Uri serviceUri, 
+            TokenCredential defaultAzureCredential,
+            TableClientOptions? tableClientOptions = null)
+            => new ()
+            {
+                ServiceUri = serviceUri,
+                AzureCredential = defaultAzureCredential,
+                TableClientOptions = tableClientOptions
+            };
+
+        /// <summary>
+        ///     Create a new <see cref="AzureTableStorageJournalSetup"/>
+        /// </summary>
+        /// <param name="tableServiceClientFactory">
+        ///     A <see cref="TableServiceClientFactory"/> to be used as the backing journal storage.
+        /// </param>
+        /// <returns>A new <see cref="AzureTableStorageJournalSetup"/> instance</returns>
+        public static AzureTableStorageJournalSetup Create(Func<TableServiceClient> tableServiceClientFactory)
+            => new ()
+            {
+                TableServiceClientFactory = tableServiceClientFactory,
+            };
+
         /// <summary>
         ///     The connection string for connecting to Windows Azure table storage.
         /// </summary>
@@ -58,6 +96,7 @@ namespace Akka.Persistence.Azure.Journal
         ///     <see cref="ConnectionString"/> will be ignored, replaced with "UseDevelopmentStorage=true" for local
         ///     connection to Azurite.
         /// </summary>
+        [Obsolete(message: "The Development property is not being applied anymore. Please set ConnectionString to 'UseDevelopmentStorage=true' instead.")]
         public bool? Development { get; set; }
         
         /// <summary>
@@ -92,6 +131,12 @@ namespace Akka.Persistence.Azure.Journal
         /// </summary>
         public TableClientOptions? TableClientOptions { get; set; }
 
+        /// <summary>
+        ///     The Azure <see cref="TableServiceClientFactory"/> to be used by the journal.
+        ///     When set, this will override any connection string or token credential in this setup.
+        /// </summary>
+        public Func<TableServiceClient>? TableServiceClientFactory { get; set; }
+        
         internal AzureTableStorageJournalSettings Apply(AzureTableStorageJournalSettings settings)
         {
             if (ConnectionString != null)
@@ -104,12 +149,12 @@ namespace Akka.Persistence.Azure.Journal
                 settings = settings.WithRequestTimeout(RequestTimeout.Value);
             if (VerboseLogging != null)
                 settings = settings.WithVerboseLogging(VerboseLogging.Value);
-            if (Development != null)
-                settings = settings.WithDevelopment(Development.Value);
             if (AutoInitialize != null)
                 settings = settings.WithAutoInitialize(AutoInitialize.Value);
             if (ServiceUri != null && AzureCredential != null)
                 settings = settings.WithAzureCredential(ServiceUri, AzureCredential, TableClientOptions);
+            if(TableServiceClientFactory != null)
+                settings = settings.WithTableServiceClientFactory(TableServiceClientFactory);
 
             return settings;
         }

--- a/src/Akka.Persistence.Azure/Snapshot/AzureBlobSnapshotSetup.cs
+++ b/src/Akka.Persistence.Azure/Snapshot/AzureBlobSnapshotSetup.cs
@@ -8,7 +8,6 @@ using System;
 using System.Collections.Generic;
 using Akka.Actor.Setup;
 using Azure.Core;
-using Azure.Identity;
 using Azure.Storage.Blobs;
 using Azure.Storage.Blobs.Models;
 
@@ -51,12 +50,25 @@ namespace Akka.Persistence.Azure.Snapshot
         public static AzureBlobSnapshotSetup Create(
             Uri serviceUri, 
             TokenCredential defaultAzureCredential,
-            BlobClientOptions? blobClientOptions = default)
-            => new AzureBlobSnapshotSetup
+            BlobClientOptions? blobClientOptions = null)
+            => new ()
             {
                 ServiceUri = serviceUri,
                 AzureCredential = defaultAzureCredential,
                 BlobClientOptions = blobClientOptions
+            };
+
+        /// <summary>
+        ///     Create a new <see cref="AzureBlobSnapshotSetup"/>
+        /// </summary>
+        /// <param name="blobServiceClient">
+        ///     A <see cref="BlobServiceClientFactory"/> to be used as the snapshot blob storage.
+        /// </param>
+        /// <returns>A new <see cref="AzureBlobSnapshotSetup"/> instance</returns>
+        public static AzureBlobSnapshotSetup Create(Func<BlobServiceClient> blobServiceClient)
+            => new ()
+            {
+                BlobServiceClientFactory = blobServiceClient,
             };
 
         /// <summary>
@@ -89,6 +101,7 @@ namespace Akka.Persistence.Azure.Snapshot
         ///     <see cref="ConnectionString"/> will be ignored, replaced with "UseDevelopmentStorage=true" for local
         ///     connection to Azurite.
         /// </summary>
+        [Obsolete(message: "The Development property is not being applied anymore. Please set ConnectionString to 'UseDevelopmentStorage=true' instead.")]
         public bool? Development { get; set; }
 
         /// <summary>
@@ -128,6 +141,12 @@ namespace Akka.Persistence.Azure.Snapshot
         /// </summary>
         public BlobClientOptions? BlobClientOptions { get; set; }
 
+        /// <summary>
+        ///     A function that returns an Azure <see cref="BlobServiceClient"/> to be used by the journal.
+        ///     When set, this will override any connection string or token credential in this setup.
+        /// </summary>
+        public Func<BlobServiceClient>? BlobServiceClientFactory { get; set; }
+        
         internal AzureBlobSnapshotStoreSettings Apply(AzureBlobSnapshotStoreSettings settings)
         {
             if (ConnectionString != null)
@@ -140,14 +159,14 @@ namespace Akka.Persistence.Azure.Snapshot
                 settings = settings.WithRequestTimeout(RequestTimeout.Value);
             if (VerboseLogging != null)
                 settings = settings.WithVerboseLogging(VerboseLogging.Value);
-            if (Development != null)
-                settings = settings.WithDevelopment(Development.Value);
             if (AutoInitialize != null)
                 settings = settings.WithAutoInitialize(AutoInitialize.Value);
             if (ContainerPublicAccessType != null)
                 settings = settings.WithContainerPublicAccessType(ContainerPublicAccessType.Value);
             if (ServiceUri != null && AzureCredential != null)
                 settings = settings.WithAzureCredential(ServiceUri, AzureCredential, BlobClientOptions);
+            if(BlobServiceClientFactory != null)
+                settings = settings.WithBlobServiceClientFactory(BlobServiceClientFactory);
 
             return settings;
         }

--- a/src/Akka.Persistence.Azure/Snapshot/AzureBlobSnapshotStore.cs
+++ b/src/Akka.Persistence.Azure/Snapshot/AzureBlobSnapshotStore.cs
@@ -15,12 +15,14 @@ using Akka.Configuration;
 using Akka.Event;
 using Akka.Persistence.Azure.Util;
 using Akka.Persistence.Snapshot;
+using Akka.Util;
 using Akka.Util.Internal;
 using Azure;
 using Azure.Storage.Blobs;
 using Azure.Storage.Blobs.Models;
 using Azure.Storage.Blobs.Specialized;
 
+#nullable enable
 namespace Akka.Persistence.Azure.Snapshot
 {
     /// <summary>
@@ -42,7 +44,6 @@ namespace Akka.Persistence.Azure.Snapshot
         private const string TimeStampMetaDataKey = "Timestamp";
         private const string SeqNoMetaDataKey = "SeqNo";
 
-        private readonly Lazy<BlobContainerClient> _containerClient;
         private readonly ILoggingAdapter _log = Context.GetLogger();
         private readonly SerializationHelper _serialization;
         private readonly AzureBlobSnapshotStoreSettings _settings;
@@ -50,7 +51,7 @@ namespace Akka.Persistence.Azure.Snapshot
 
         private readonly CancellationTokenSource _shutdownCts;
 
-        public AzureBlobSnapshotStore(Config config = null)
+        public AzureBlobSnapshotStore(Config? config = null)
         {
             _serialization = new SerializationHelper(Context.System);
             _settings = config is null
@@ -65,14 +66,14 @@ namespace Akka.Persistence.Azure.Snapshot
             if (multiSetup.HasValue)
             {
                 var snapshotId = Self.Path.Name.SplitDottedPathHonouringQuotes().Last();
-                setup = multiSetup.Value.Get(snapshotId);
+                setup = Option<AzureBlobSnapshotSetup>.Create(multiSetup.Value!.Get(snapshotId)!);
                 if(setup.HasValue)
                     _settings = setup.Value.Apply(_settings);
             }
             
-            if (_settings.Development)
+            if (_settings.BlobServiceClientFactory != null)
             {
-                _serviceClient = new BlobServiceClient(connectionString: "UseDevelopmentStorage=true");
+                _serviceClient = _settings.BlobServiceClientFactory.Invoke();
             }
             else
             {
@@ -81,15 +82,17 @@ namespace Akka.Persistence.Azure.Snapshot
                         serviceUri: _settings.ServiceUri, 
                         credential: _settings.AzureCredential,
                         options: _settings.BlobClientOptions)
-                    : _serviceClient = new BlobServiceClient(connectionString: _settings.ConnectionString);
+                    : !string.IsNullOrWhiteSpace(_settings.ConnectionString) 
+                        ? _serviceClient = new BlobServiceClient(connectionString: _settings.ConnectionString)
+                        : throw new ConfigurationException(
+                            "No connection method configured. ConnectionString, AzureCredential, or BlobServiceClient " +
+                            "must be specified.");
             }
 
             _shutdownCts = new CancellationTokenSource();
-            _containerClient = new Lazy<BlobContainerClient>(() => 
-                InitCloudStorage(5, _shutdownCts.Token).GetAwaiter().GetResult());
         }
 
-        public BlobContainerClient Container => _containerClient.Value;
+        public BlobContainerClient Container => _serviceClient.GetBlobContainerClient(_settings.ContainerName);
 
         private async Task<BlobContainerClient> InitCloudStorage(int remainingTries, CancellationToken cancellationToken)
         {
@@ -156,8 +159,7 @@ namespace Akka.Persistence.Azure.Snapshot
         {
             _log.Debug("Initializing Azure Container Storage...");
 
-            // forces loading of the value
-            var name = Container.Name;
+            InitCloudStorage(5, _shutdownCts.Token).GetAwaiter().GetResult();
 
             _log.Debug("Successfully started Azure Container Storage!");
 

--- a/src/Akka.Persistence.Azure/Snapshot/AzureBlobSnapshotStoreSettings.cs
+++ b/src/Akka.Persistence.Azure/Snapshot/AzureBlobSnapshotStoreSettings.cs
@@ -9,10 +9,10 @@ using Akka.Actor;
 using Akka.Configuration;
 using Akka.Persistence.Azure.Util;
 using Azure.Core;
-using Azure.Identity;
 using Azure.Storage.Blobs;
 using Azure.Storage.Blobs.Models;
 
+#nullable enable
 namespace Akka.Persistence.Azure.Snapshot
 {
     /// <summary>
@@ -23,21 +23,34 @@ namespace Akka.Persistence.Azure.Snapshot
     {
         public const string SnapshotStoreConfigPath = "akka.persistence.snapshot-store.azure-blob-store";
         
-        [Obsolete]
+        // ReSharper disable IntroduceOptionalParameters.Global
+        [Obsolete(message:"Use constructor with containerPublicAccessType, serviceUri, defaultAzureCredential, tableClientOptions, and blobServiceClient argument instead.")]
         public AzureBlobSnapshotStoreSettings(
-            string connectionString, 
+            string? connectionString, 
             string containerName,
             TimeSpan connectTimeout, 
             TimeSpan requestTimeout, 
             bool verboseLogging, 
             bool development,
             bool autoInitialize)
-            : this(connectionString, containerName, connectTimeout, requestTimeout, verboseLogging, development, autoInitialize, PublicAccessType.BlobContainer)
+            : this(
+                connectionString: connectionString,
+                containerName: containerName,
+                connectTimeout: connectTimeout,
+                requestTimeout: requestTimeout,
+                verboseLogging: verboseLogging,
+                development: development,
+                autoInitialize: autoInitialize,
+                containerPublicAccessType: PublicAccessType.BlobContainer,
+                serviceUri: null,
+                defaultAzureCredential: null,
+                blobClientOption: null, 
+                blobServiceClientFactory: null)
         { }
 
-        [Obsolete]
+        [Obsolete(message:"Use constructor with serviceUri, defaultAzureCredential, tableClientOptions, and blobServiceClient argument instead.")]
         public AzureBlobSnapshotStoreSettings(
-            string connectionString, 
+            string? connectionString, 
             string containerName,
             TimeSpan connectTimeout, 
             TimeSpan requestTimeout, 
@@ -56,9 +69,11 @@ namespace Akka.Persistence.Azure.Snapshot
                 containerPublicAccessType: containerPublicAccessType,
                 serviceUri: null,
                 defaultAzureCredential: null,
-                blobClientOption: null)
+                blobClientOption: null, 
+                blobServiceClientFactory: null)
         { }
 
+        [Obsolete(message:"Use constructor with blobServiceClient argument instead.")]
         public AzureBlobSnapshotStoreSettings(
             string connectionString, 
             string containerName,
@@ -68,9 +83,38 @@ namespace Akka.Persistence.Azure.Snapshot
             bool development, 
             bool autoInitialize, 
             PublicAccessType containerPublicAccessType,
-            Uri serviceUri,
-            TokenCredential defaultAzureCredential,
-            BlobClientOptions blobClientOption)
+            Uri? serviceUri,
+            TokenCredential? defaultAzureCredential,
+            BlobClientOptions? blobClientOption)
+            : this(
+                connectionString: connectionString,
+                containerName: containerName,
+                connectTimeout: connectTimeout,
+                requestTimeout: requestTimeout,
+                verboseLogging: verboseLogging,
+                development: development,
+                autoInitialize: autoInitialize,
+                containerPublicAccessType: containerPublicAccessType,
+                serviceUri: serviceUri,
+                defaultAzureCredential: defaultAzureCredential,
+                blobClientOption: blobClientOption,
+                blobServiceClientFactory: null)
+        { }
+        // ReSharper restore IntroduceOptionalParameters.Global
+            
+        public AzureBlobSnapshotStoreSettings(
+            string? connectionString, 
+            string containerName,
+            TimeSpan connectTimeout, 
+            TimeSpan requestTimeout, 
+            bool verboseLogging, 
+            bool development, 
+            bool autoInitialize, 
+            PublicAccessType containerPublicAccessType,
+            Uri? serviceUri,
+            TokenCredential? defaultAzureCredential,
+            BlobClientOptions? blobClientOption,
+            Func<BlobServiceClient>? blobServiceClientFactory)
         {
             if (string.IsNullOrWhiteSpace(containerName))
                 throw new ConfigurationException("[AzureBlobSnapshotStore] Container name is null or empty.");
@@ -81,18 +125,18 @@ namespace Akka.Persistence.Azure.Snapshot
             RequestTimeout = requestTimeout;
             ConnectTimeout = connectTimeout;
             VerboseLogging = verboseLogging;
-            Development = development;
             AutoInitialize = autoInitialize;
             ContainerPublicAccessType = containerPublicAccessType;
             ServiceUri = serviceUri;
             AzureCredential = defaultAzureCredential;
             BlobClientOptions = blobClientOption;
+            BlobServiceClientFactory = blobServiceClientFactory;
         }
 
         /// <summary>
         ///     The connection string for connecting to Windows Azure blob storage account.
         /// </summary>
-        public string ConnectionString { get; }
+        public string? ConnectionString { get; }
 
         /// <summary>
         ///     The table of the container we'll be using to serialize these blobs.
@@ -119,7 +163,8 @@ namespace Akka.Persistence.Azure.Snapshot
         ///     <see cref="ConnectionString"/> will be ignored, replaced with "UseDevelopmentStorage=true" for local
         ///     connection to Azurite.
         /// </summary>
-        public bool Development { get; }
+        [Obsolete(message: "The Development property is not being applied anymore. Please set ConnectionString to 'UseDevelopmentStorage=true' instead.")]
+        public bool Development => false;
 
         /// <summary>
         ///     Automatically create the Blog Storage container if no existing Blob container is found
@@ -135,25 +180,30 @@ namespace Akka.Persistence.Azure.Snapshot
         ///     A <see cref="Uri"/> referencing the blob service.
         ///     This is likely to be similar to "https://{account_name}.blob.core.windows.net".
         /// </summary>
-        public Uri ServiceUri { get; }
+        public Uri? ServiceUri { get; }
 
         /// <summary>
         ///     The <see cref="TokenCredential"/> used to sign API requests.
         /// </summary>
         [Obsolete(message:"Use AzureCredential instead")]
-        public TokenCredential DefaultAzureCredential => AzureCredential;
+        public TokenCredential? DefaultAzureCredential => AzureCredential;
 
         /// <summary>
         ///     The <see cref="TokenCredential"/> used to sign API requests.
         /// </summary>
-        public TokenCredential AzureCredential { get; }
-        
+        public TokenCredential? AzureCredential { get; }
         
         /// <summary>
         ///     Optional client options that define the transport pipeline policies for authentication,
         ///     retries, etc., that are applied to every request.
         /// </summary>
-        public BlobClientOptions BlobClientOptions { get; }
+        public BlobClientOptions? BlobClientOptions { get; }
+        
+        /// <summary>
+        ///     A function that returns an Azure <see cref="BlobServiceClient"/> to be used by the snapshot store.
+        ///     When set, this will override any connection string or token credential in this setup.
+        /// </summary>
+        public Func<BlobServiceClient>? BlobServiceClientFactory { get; }
 
         public AzureBlobSnapshotStoreSettings WithConnectionString(string connectionString)
             => Copy(connectionString: connectionString);
@@ -165,8 +215,8 @@ namespace Akka.Persistence.Azure.Snapshot
             => Copy(requestTimeout: requestTimeout);
         public AzureBlobSnapshotStoreSettings WithVerboseLogging(bool verboseLogging)
             => Copy(verboseLogging: verboseLogging);
-        public AzureBlobSnapshotStoreSettings WithDevelopment(bool development)
-            => Copy(development: development);
+        [Obsolete(message: "The Development property is not being applied anymore. Please set ConnectionString to 'UseDevelopmentStorage=true' instead.")]
+        public AzureBlobSnapshotStoreSettings WithDevelopment(bool development) => this;
         public AzureBlobSnapshotStoreSettings WithAutoInitialize(bool autoInitialize)
             => Copy(autoInitialize: autoInitialize);
         public AzureBlobSnapshotStoreSettings WithContainerPublicAccessType(PublicAccessType containerPublicAccessType)
@@ -174,36 +224,39 @@ namespace Akka.Persistence.Azure.Snapshot
         public AzureBlobSnapshotStoreSettings WithAzureCredential(
             Uri serviceUri,
             TokenCredential defaultAzureCredential,
-            BlobClientOptions blobClientOption = null)
+            BlobClientOptions? blobClientOption = null)
             => Copy(
                 serviceUri: serviceUri,
                 azureCredential: defaultAzureCredential,
                 blobClientOption: blobClientOption);
+        public AzureBlobSnapshotStoreSettings WithBlobServiceClientFactory(Func<BlobServiceClient> blobServiceClient)
+            => Copy(blobServiceClientFactory: blobServiceClient);
         
         private AzureBlobSnapshotStoreSettings Copy(
-            string connectionString = null,
-            string containerName = null,
+            string? connectionString = null,
+            string? containerName = null,
             TimeSpan? connectTimeout = null,
             TimeSpan? requestTimeout = null,
             bool? verboseLogging = null,
-            bool? development = null,
             bool? autoInitialize = null,
             PublicAccessType? containerPublicAccessType = null,
-            Uri serviceUri = null,
-            TokenCredential azureCredential = null,
-            BlobClientOptions blobClientOption = null)
-            => new AzureBlobSnapshotStoreSettings(
-                connectionString ?? ConnectionString,
-                containerName ?? ContainerName,
-                connectTimeout ?? ConnectTimeout,
-                requestTimeout ?? RequestTimeout,
-                verboseLogging ?? VerboseLogging,
-                development ?? Development,
-                autoInitialize ?? AutoInitialize,
-                containerPublicAccessType ?? ContainerPublicAccessType,
-                serviceUri ?? ServiceUri,
-                azureCredential ?? AzureCredential,
-                blobClientOption ?? BlobClientOptions);
+            Uri? serviceUri = null,
+            TokenCredential? azureCredential = null,
+            BlobClientOptions? blobClientOption = null,
+            Func<BlobServiceClient>? blobServiceClientFactory = null)
+            => new (
+                connectionString: connectionString ?? ConnectionString,
+                containerName: containerName ?? ContainerName,
+                connectTimeout: connectTimeout ?? ConnectTimeout,
+                requestTimeout: requestTimeout ?? RequestTimeout,
+                verboseLogging: verboseLogging ?? VerboseLogging,
+                development: false,
+                autoInitialize: autoInitialize ?? AutoInitialize,
+                containerPublicAccessType: containerPublicAccessType ?? ContainerPublicAccessType,
+                serviceUri: serviceUri ?? ServiceUri,
+                defaultAzureCredential: azureCredential ?? AzureCredential,
+                blobClientOption: blobClientOption ?? BlobClientOptions,
+                blobServiceClientFactory: blobServiceClientFactory ?? BlobServiceClientFactory);
         
         /// <summary>
         ///     Creates an <see cref="AzureBlobSnapshotStoreSettings" /> instance using the
@@ -256,7 +309,8 @@ namespace Akka.Persistence.Azure.Snapshot
                 containerPublicAccessType: containerPublicAccessType,
                 serviceUri: null,
                 defaultAzureCredential: null,
-                blobClientOption: null);
+                blobClientOption: null, 
+                blobServiceClientFactory: null);
         }
     }
 }


### PR DESCRIPTION
* Add a `Func<TableServiceClient>` option/setting/setup property so user can inject their own `TableServiceClient` instance into the journal
* Add a `Func<BlobServiceClient>` option/setting/setup property so user can inject their own `BlobServiceClient` instance into the snapshot store