### PR TITLE
Add folder support to SnapshotStore

### DIFF
--- a/src/Akka.Persistence.Azure.API.Tests/Akka.Persistence.Azure.API.Tests.csproj
+++ b/src/Akka.Persistence.Azure.API.Tests/Akka.Persistence.Azure.API.Tests.csproj
@@ -27,4 +27,13 @@
     <ProjectReference Include="..\Akka.Persistence.Azure\Akka.Persistence.Azure.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <None Update="verify\BlobNameSpecs.VerifyToJournalRowKey.DotNet.verified.txt">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="verify\BlobNameSpecs.VerifyToSnapshotSearchQuery.DotNet.verified.txt">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
 </Project>

--- a/src/Akka.Persistence.Azure.API.Tests/BlobNameSpecs.cs
+++ b/src/Akka.Persistence.Azure.API.Tests/BlobNameSpecs.cs
@@ -1,4 +1,5 @@
-﻿using Akka.Persistence.Azure.Util;
+﻿using Akka.Persistence.Azure.Snapshot;
+using Akka.Persistence.Azure.Util;
 
 namespace Akka.Persistence.Azure.API.Tests;
 
@@ -8,13 +9,26 @@ public class BlobNameSpecs
     public async Task VerifyToJournalRowKey()
     {
         var metadata = new SnapshotMetadata("persistenceId", 100, new DateTime(2000, 1, 1));
-        await Verify(metadata.ToSnapshotBlobId());
+        await Verify(metadata.ToSnapshotBlobId(string.Empty));
+        
+        var verifiedToJournalRowKey = File.ReadAllText("./verify/BlobNameSpecs.VerifyToJournalRowKey.DotNet.verified.txt");
+        Assert.Equal(verifiedToJournalRowKey, metadata.ToSnapshotBlobId("  "));
+        Assert.Equal(verifiedToJournalRowKey, metadata.ToSnapshotBlobId(null));
+        Assert.Equal(verifiedToJournalRowKey, metadata.ToSnapshotBlobId(AzureBlobSnapshotStoreSettings.SanitizeFolder("/")));
+        Assert.Equal(verifiedToJournalRowKey, metadata.ToSnapshotBlobId(AzureBlobSnapshotStoreSettings.SanitizeFolder("/ ")));
+        Assert.Equal(verifiedToJournalRowKey, metadata.ToSnapshotBlobId(AzureBlobSnapshotStoreSettings.SanitizeFolder(" /")));
     }
     
     [Fact]
     public async Task VerifyToSnapshotSearchQuery()
     {
-        await Verify(SeqNoHelper.ToSnapshotSearchQuery("persistenceId"));
+        await Verify(SeqNoHelper.ToSnapshotSearchQuery("persistenceId", string.Empty));
+        
+        var verifiedToSnapshotSearchQuery = File.ReadAllText("./verify/BlobNameSpecs.VerifyToSnapshotSearchQuery.DotNet.verified.txt");
+        Assert.Equal(verifiedToSnapshotSearchQuery, SeqNoHelper.ToSnapshotSearchQuery("persistenceId", "  "));
+        Assert.Equal(verifiedToSnapshotSearchQuery, SeqNoHelper.ToSnapshotSearchQuery("persistenceId", null));
+        Assert.Equal(verifiedToSnapshotSearchQuery, SeqNoHelper.ToSnapshotSearchQuery("persistenceId", AzureBlobSnapshotStoreSettings.SanitizeFolder("/")));
+        Assert.Equal(verifiedToSnapshotSearchQuery, SeqNoHelper.ToSnapshotSearchQuery("persistenceId", AzureBlobSnapshotStoreSettings.SanitizeFolder(" /")));
+        Assert.Equal(verifiedToSnapshotSearchQuery, SeqNoHelper.ToSnapshotSearchQuery("persistenceId", AzureBlobSnapshotStoreSettings.SanitizeFolder("/ ")));
     }
-    
 }

--- a/src/Akka.Persistence.Azure.API.Tests/verify/ApiSpecs.ApproveCore.DotNet.verified.txt
+++ b/src/Akka.Persistence.Azure.API.Tests/verify/ApiSpecs.ApproveCore.DotNet.verified.txt
@@ -273,7 +273,11 @@ namespace Akka.Persistence.Azure.Snapshot
         public AzureBlobSnapshotStoreSettings([System.Runtime.CompilerServices.NullableAttribute(2)] string connectionString, string containerName, System.TimeSpan connectTimeout, System.TimeSpan requestTimeout, bool verboseLogging, bool development, bool autoInitialize, Azure.Storage.Blobs.Models.PublicAccessType containerPublicAccessType) { }
         [System.ObsoleteAttribute("Use constructor with blobServiceClient argument instead.")]
         public AzureBlobSnapshotStoreSettings([System.Runtime.CompilerServices.NullableAttribute(1)] string connectionString, [System.Runtime.CompilerServices.NullableAttribute(1)] string containerName, System.TimeSpan connectTimeout, System.TimeSpan requestTimeout, bool verboseLogging, bool development, bool autoInitialize, Azure.Storage.Blobs.Models.PublicAccessType containerPublicAccessType, System.Uri serviceUri, Azure.Core.TokenCredential defaultAzureCredential, Azure.Storage.Blobs.BlobClientOptions blobClientOption) { }
+        [System.ObsoleteAttribute("Use constructor with folders argument instead.")]
         public AzureBlobSnapshotStoreSettings(string connectionString, [System.Runtime.CompilerServices.NullableAttribute(1)] string containerName, System.TimeSpan connectTimeout, System.TimeSpan requestTimeout, bool verboseLogging, bool development, bool autoInitialize, Azure.Storage.Blobs.Models.PublicAccessType containerPublicAccessType, System.Uri serviceUri, Azure.Core.TokenCredential defaultAzureCredential, Azure.Storage.Blobs.BlobClientOptions blobClientOption, [System.Runtime.CompilerServices.NullableAttribute(new byte[] {
+                2,
+                1})] System.Func<Azure.Storage.Blobs.BlobServiceClient> blobServiceClientFactory) { }
+        public AzureBlobSnapshotStoreSettings(string connectionString, [System.Runtime.CompilerServices.NullableAttribute(1)] string containerName, [System.Runtime.CompilerServices.NullableAttribute(1)] string folders, System.TimeSpan connectTimeout, System.TimeSpan requestTimeout, bool verboseLogging, bool development, bool autoInitialize, Azure.Storage.Blobs.Models.PublicAccessType containerPublicAccessType, System.Uri serviceUri, Azure.Core.TokenCredential defaultAzureCredential, Azure.Storage.Blobs.BlobClientOptions blobClientOption, [System.Runtime.CompilerServices.NullableAttribute(new byte[] {
                 2,
                 1})] System.Func<Azure.Storage.Blobs.BlobServiceClient> blobServiceClientFactory) { }
         public bool AutoInitialize { get; }
@@ -296,12 +300,14 @@ namespace Akka.Persistence.Azure.Snapshot
         [System.ObsoleteAttribute("The Development property is not being applied anymore. Please set ConnectionStrin" +
             "g to \'UseDevelopmentStorage=true\' instead.")]
         public bool Development { get; }
+        public string Folders { get; }
         public System.TimeSpan RequestTimeout { get; }
         [System.Runtime.CompilerServices.NullableAttribute(2)]
         public System.Uri ServiceUri { get; }
         public bool VerboseLogging { get; }
         public static Akka.Persistence.Azure.Snapshot.AzureBlobSnapshotStoreSettings Create(Akka.Actor.ActorSystem system) { }
         public static Akka.Persistence.Azure.Snapshot.AzureBlobSnapshotStoreSettings Create(Akka.Configuration.Config config) { }
+        public static string SanitizeFolder([System.Runtime.CompilerServices.NullableAttribute(2)] string folder) { }
         public Akka.Persistence.Azure.Snapshot.AzureBlobSnapshotStoreSettings WithAutoInitialize(bool autoInitialize) { }
         public Akka.Persistence.Azure.Snapshot.AzureBlobSnapshotStoreSettings WithAzureCredential(System.Uri serviceUri, Azure.Core.TokenCredential defaultAzureCredential, [System.Runtime.CompilerServices.NullableAttribute(2)] Azure.Storage.Blobs.BlobClientOptions blobClientOption = null) { }
         public Akka.Persistence.Azure.Snapshot.AzureBlobSnapshotStoreSettings WithBlobServiceClientFactory(System.Func<Azure.Storage.Blobs.BlobServiceClient> blobServiceClient) { }

--- a/src/Akka.Persistence.Azure.API.Tests/verify/ApiSpecs.ApproveHosting.DotNet.verified.txt
+++ b/src/Akka.Persistence.Azure.API.Tests/verify/ApiSpecs.ApproveHosting.DotNet.verified.txt
@@ -18,6 +18,7 @@ namespace Akka.Persistence.Azure.Hosting
         public string ContainerName { get; set; }
         public System.Nullable<Azure.Storage.Blobs.Models.PublicAccessType> ContainerPublicAccessType { get; set; }
         public System.Nullable<bool> Development { get; set; }
+        public string Folders { get; set; }
         [System.Runtime.CompilerServices.NullableAttribute(1)]
         public override string Identifier { get; set; }
         [System.Runtime.CompilerServices.NullableAttribute(1)]

--- a/src/Akka.Persistence.Azure.Hosting/AzureBlobSnapshotOptions.cs
+++ b/src/Akka.Persistence.Azure.Hosting/AzureBlobSnapshotOptions.cs
@@ -46,6 +46,17 @@ namespace Akka.Persistence.Azure.Hosting
         public string? ContainerName { get; set; }
 
         /// <summary>
+        ///     The "folder" or "directory" where snapshot files will be stored.
+        ///     Note that Azure Blob Storage does not implement a true folder tree structure,
+        ///     "folder" names are actually a simple prefix to the blob file name.
+        /// </summary>
+        /// <example>
+        ///     If you set this setting to "folder1/folder2", then the snapshots will be stored as:
+        ///         /{account name}/akka-persistence-default-container/folder1/folder2/snapshot-{persistence id}-{sequence number}
+        /// </example>
+        public string? Folders { get; set; }
+        
+        /// <summary>
         ///     Initial timeout to use when connecting to Azure Container Storage for the first time.
         /// </summary>
         public TimeSpan? ConnectTimeout { get; set; }
@@ -107,6 +118,9 @@ namespace Akka.Persistence.Azure.Hosting
             if (ContainerName is { })
                 sb.AppendLine($"container-name = {ContainerName.ToHocon()}");
 
+            if (Folders is { })
+                sb.AppendLine($"folders = {ContainerName.ToHocon()}");
+            
             if (ConnectTimeout is { })
                 sb.AppendLine($"connect-timeout = {ConnectTimeout.ToHocon()}");
 

--- a/src/Akka.Persistence.Azure.Hosting/AzureBlobSnapshotOptions.cs
+++ b/src/Akka.Persistence.Azure.Hosting/AzureBlobSnapshotOptions.cs
@@ -119,7 +119,7 @@ namespace Akka.Persistence.Azure.Hosting
                 sb.AppendLine($"container-name = {ContainerName.ToHocon()}");
 
             if (Folders is { })
-                sb.AppendLine($"folders = {ContainerName.ToHocon()}");
+                sb.AppendLine($"folders = {AzureBlobSnapshotStoreSettings.SanitizeFolder(Folders.ToHocon())}");
             
             if (ConnectTimeout is { })
                 sb.AppendLine($"connect-timeout = {ConnectTimeout.ToHocon()}");

--- a/src/Akka.Persistence.Azure.Tests/AzureBlobSnapshotStoreCustomFolderSpec.cs
+++ b/src/Akka.Persistence.Azure.Tests/AzureBlobSnapshotStoreCustomFolderSpec.cs
@@ -1,0 +1,43 @@
+// -----------------------------------------------------------------------
+// <copyright file="AzureBlobSnapshotStoreSpec.cs" company="Petabridge, LLC">
+//      Copyright (C) 2015 - 2023 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System;
+using Akka.Configuration;
+using Akka.Persistence.Azure.Snapshot;
+using Akka.Persistence.Azure.Tests.Helper;
+using Akka.Persistence.TCK.Snapshot;
+using FluentAssertions;
+using Xunit;
+using Xunit.Abstractions;
+using static Akka.Persistence.Azure.Tests.Helper.AzureStorageConfigHelper;
+
+namespace Akka.Persistence.Azure.Tests
+{
+    [Collection("AzureSpecs")]
+    public class AzureBlobSnapshotStoreCustomFolderSpec : SnapshotStoreSpec
+    {
+        private static readonly Config CustomConfig = ConfigurationFactory
+            .ParseString("akka.persistence.snapshot-store.azure-blob-store.folders = \"/folder-1/folder-2/\"")
+            .WithFallback(AzureConfig());
+    
+        public AzureBlobSnapshotStoreCustomFolderSpec(ITestOutputHelper output) 
+            : base(CustomConfig, nameof(AzureBlobSnapshotStoreCustomFolderSpec), output)
+        {
+            AzurePersistence.Get(Sys);
+            Initialize();
+        }
+
+        [Fact]
+        public void ConfigTest()
+        {
+            var settings = AzureBlobSnapshotStoreSettings.Create(Sys);
+            settings.Folders.Should().Be("folder-1/folder-2");
+            
+            settings = AzureBlobSnapshotStoreSettings.Create(Sys.Settings.Config.GetConfig(AzureBlobSnapshotStoreSettings.SnapshotStoreConfigPath));
+            settings.Folders.Should().Be("folder-1/folder-2");
+        }
+    }
+}

--- a/src/Akka.Persistence.Azure.Tests/AzureSnapshotStoreCustomFolderSaveSnapshotSpec.cs
+++ b/src/Akka.Persistence.Azure.Tests/AzureSnapshotStoreCustomFolderSaveSnapshotSpec.cs
@@ -1,0 +1,22 @@
+﻿using Akka.Configuration;
+using Akka.Persistence.TCK.Snapshot;
+using Xunit;
+using Xunit.Abstractions;
+using static Akka.Persistence.Azure.Tests.Helper.AzureStorageConfigHelper;
+
+namespace Akka.Persistence.Azure.Tests;
+
+[Collection("AzureSpecs")]
+public class AzureSnapshotStoreCustomFolderSaveSnapshotSpec: SnapshotStoreSaveSnapshotSpec
+{
+    private static readonly Config CustomConfig = ConfigurationFactory
+        .ParseString("akka.persistence.snapshot-store.azure-blob-store.folders = \"folder-1/folder-2\"")
+        .WithFallback(AzureConfig());
+    
+    public AzureSnapshotStoreCustomFolderSaveSnapshotSpec(ITestOutputHelper output) 
+        : base(CustomConfig, nameof(AzureSnapshotStoreCustomFolderSaveSnapshotSpec), output)
+    {
+        AzurePersistence.Get(Sys);
+    }
+    
+}

--- a/src/Akka.Persistence.Azure/Snapshot/AzureBlobSnapshotStore.cs
+++ b/src/Akka.Persistence.Azure/Snapshot/AzureBlobSnapshotStore.cs
@@ -183,7 +183,7 @@ namespace Akka.Persistence.Azure.Snapshot
             using(cts)
             {
                 var results = Container.GetBlobsAsync(
-                    prefix: SeqNoHelper.ToSnapshotSearchQuery(persistenceId), 
+                    prefix: SeqNoHelper.ToSnapshotSearchQuery(persistenceId, _settings.Folders), 
                     traits: BlobTraits.Metadata,
                     cancellationToken: cts.Token);
 
@@ -227,7 +227,7 @@ namespace Akka.Persistence.Azure.Snapshot
 
         protected override async Task SaveAsync(SnapshotMetadata metadata, object snapshot)
         {
-            var blobClient = Container.GetBlockBlobClient(metadata.ToSnapshotBlobId());
+            var blobClient = Container.GetBlockBlobClient(metadata.ToSnapshotBlobId(_settings.Folders));
             var snapshotData = _serialization.SnapshotToBytes(new Serialization.Snapshot(snapshot));
 
             var cts = CancellationTokenSource.CreateLinkedTokenSource(_shutdownCts.Token);
@@ -256,7 +256,7 @@ namespace Akka.Persistence.Azure.Snapshot
 
         protected override async Task DeleteAsync(SnapshotMetadata metadata)
         {
-            var blobClient = Container.GetBlobClient(metadata.ToSnapshotBlobId());
+            var blobClient = Container.GetBlobClient(metadata.ToSnapshotBlobId(_settings.Folders));
 
             var cts = CancellationTokenSource.CreateLinkedTokenSource(_shutdownCts.Token);
             cts.CancelAfter(_settings.RequestTimeout);
@@ -287,7 +287,7 @@ namespace Akka.Persistence.Azure.Snapshot
             using (cts)
             {
                 var items = Container.GetBlobsAsync(
-                    prefix: SeqNoHelper.ToSnapshotSearchQuery(persistenceId), 
+                    prefix: SeqNoHelper.ToSnapshotSearchQuery(persistenceId, _settings.Folders), 
                     traits: BlobTraits.Metadata,
                     cancellationToken: cts.Token);
 

--- a/src/Akka.Persistence.Azure/Snapshot/AzureBlobSnapshotStoreSettings.cs
+++ b/src/Akka.Persistence.Azure/Snapshot/AzureBlobSnapshotStoreSettings.cs
@@ -318,6 +318,9 @@ namespace Akka.Persistence.Azure.Snapshot
             return Create(config);
         }
         
+        public static string SanitizeFolder(string? folder)
+            => folder?.Trim().Trim('/') ?? string.Empty;
+        
         /// <summary>
         ///     Creates an <see cref="AzureBlobSnapshotStoreSettings" /> instance using the
         ///     `akka.persistence.snapshot-store.azure-blob-store` HOCON configuration section.
@@ -331,7 +334,7 @@ namespace Akka.Persistence.Azure.Snapshot
             
             var connectionString = config.GetString("connection-string");
             var containerName = config.GetString("container-name");
-            var folders = config.GetString("folders", string.Empty).Trim().Trim('/');
+            var folders = SanitizeFolder(config.GetString("folders"));
             var connectTimeout = config.GetTimeSpan("connect-timeout", TimeSpan.FromSeconds(3));
             var requestTimeout = config.GetTimeSpan("request-timeout", TimeSpan.FromSeconds(3));
             var verbose = config.GetBoolean("verbose-logging", false);

--- a/src/Akka.Persistence.Azure/Snapshot/AzureBlobSnapshotStoreSettings.cs
+++ b/src/Akka.Persistence.Azure/Snapshot/AzureBlobSnapshotStoreSettings.cs
@@ -100,11 +100,42 @@ namespace Akka.Persistence.Azure.Snapshot
                 blobClientOption: blobClientOption,
                 blobServiceClientFactory: null)
         { }
-        // ReSharper restore IntroduceOptionalParameters.Global
-            
+
+        [Obsolete(message:"Use constructor with folders argument instead.")]
         public AzureBlobSnapshotStoreSettings(
             string? connectionString, 
             string containerName,
+            TimeSpan connectTimeout, 
+            TimeSpan requestTimeout, 
+            bool verboseLogging, 
+            bool development, 
+            bool autoInitialize, 
+            PublicAccessType containerPublicAccessType,
+            Uri? serviceUri,
+            TokenCredential? defaultAzureCredential,
+            BlobClientOptions? blobClientOption,
+            Func<BlobServiceClient>? blobServiceClientFactory)
+            : this(
+                connectionString: connectionString,
+                containerName: containerName,
+                folders: string.Empty,
+                connectTimeout: connectTimeout,
+                requestTimeout: requestTimeout,
+                verboseLogging: verboseLogging,
+                development: development,
+                autoInitialize: autoInitialize,
+                containerPublicAccessType: containerPublicAccessType,
+                serviceUri: serviceUri,
+                defaultAzureCredential: defaultAzureCredential,
+                blobClientOption: blobClientOption,
+                blobServiceClientFactory: blobServiceClientFactory)
+        { }
+        // ReSharper restore IntroduceOptionalParameters.Global
+        
+        public AzureBlobSnapshotStoreSettings(
+            string? connectionString, 
+            string containerName,
+            string folders,
             TimeSpan connectTimeout, 
             TimeSpan requestTimeout, 
             bool verboseLogging, 
@@ -122,6 +153,7 @@ namespace Akka.Persistence.Azure.Snapshot
             NameValidator.ValidateContainerName(containerName);
             ConnectionString = connectionString;
             ContainerName = containerName;
+            Folders = folders;
             RequestTimeout = requestTimeout;
             ConnectTimeout = connectTimeout;
             VerboseLogging = verboseLogging;
@@ -142,6 +174,17 @@ namespace Akka.Persistence.Azure.Snapshot
         ///     The table of the container we'll be using to serialize these blobs.
         /// </summary>
         public string ContainerName { get; }
+        
+        /// <summary>
+        ///     The "folder" or "directory" where snapshot files will be stored.
+        ///     Note that Azure Blob Storage does not implement a true folder tree structure,
+        ///     "folder" names are actually a simple prefix to the blob file name.
+        /// </summary>
+        /// <example>
+        ///     If you set this setting to "folder1/folder2", then the snapshots will be stored as:
+        ///         /{account name}/akka-persistence-default-container/folder1/folder2/snapshot-{persistence id}-{sequence number}
+        /// </example>
+        public string Folders { get; }
 
         /// <summary>
         ///     Initial timeout to use when connecting to Azure Container Storage for the first time.
@@ -235,6 +278,7 @@ namespace Akka.Persistence.Azure.Snapshot
         private AzureBlobSnapshotStoreSettings Copy(
             string? connectionString = null,
             string? containerName = null,
+            string? folders = null,
             TimeSpan? connectTimeout = null,
             TimeSpan? requestTimeout = null,
             bool? verboseLogging = null,
@@ -247,6 +291,7 @@ namespace Akka.Persistence.Azure.Snapshot
             => new (
                 connectionString: connectionString ?? ConnectionString,
                 containerName: containerName ?? ContainerName,
+                folders: folders ?? Folders,
                 connectTimeout: connectTimeout ?? ConnectTimeout,
                 requestTimeout: requestTimeout ?? RequestTimeout,
                 verboseLogging: verboseLogging ?? VerboseLogging,
@@ -286,6 +331,7 @@ namespace Akka.Persistence.Azure.Snapshot
             
             var connectionString = config.GetString("connection-string");
             var containerName = config.GetString("container-name");
+            var folders = config.GetString("folders").Trim().Trim('/');
             var connectTimeout = config.GetTimeSpan("connect-timeout", TimeSpan.FromSeconds(3));
             var requestTimeout = config.GetTimeSpan("request-timeout", TimeSpan.FromSeconds(3));
             var verbose = config.GetBoolean("verbose-logging", false);
@@ -301,6 +347,7 @@ namespace Akka.Persistence.Azure.Snapshot
             return new AzureBlobSnapshotStoreSettings(
                 connectionString: connectionString, 
                 containerName: containerName, 
+                folders: folders,
                 connectTimeout: connectTimeout, 
                 requestTimeout: requestTimeout,
                 verboseLogging: verbose,

--- a/src/Akka.Persistence.Azure/Snapshot/AzureBlobSnapshotStoreSettings.cs
+++ b/src/Akka.Persistence.Azure/Snapshot/AzureBlobSnapshotStoreSettings.cs
@@ -331,7 +331,7 @@ namespace Akka.Persistence.Azure.Snapshot
             
             var connectionString = config.GetString("connection-string");
             var containerName = config.GetString("container-name");
-            var folders = config.GetString("folders").Trim().Trim('/');
+            var folders = config.GetString("folders", string.Empty).Trim().Trim('/');
             var connectTimeout = config.GetTimeSpan("connect-timeout", TimeSpan.FromSeconds(3));
             var requestTimeout = config.GetTimeSpan("request-timeout", TimeSpan.FromSeconds(3));
             var verbose = config.GetBoolean("verbose-logging", false);

--- a/src/Akka.Persistence.Azure/Util/SeqNoHelper.cs
+++ b/src/Akka.Persistence.Azure/Util/SeqNoHelper.cs
@@ -37,20 +37,26 @@ namespace Akka.Persistence.Azure.Util
         /// into lexicographical order for a particular snapshot.
         /// </summary>
         /// <param name="metadata">The metadata used for the current snapshot.</param>
+        /// <param name="folders">Folder prefix added to the front of the file name</param>
         /// <returns>A Uri-friendly snapshot blob name.</returns>
-        public static string ToSnapshotBlobId(this SnapshotMetadata metadata)
+        public static string ToSnapshotBlobId(this SnapshotMetadata metadata, string folders)
         {
-            return $"snapshot-{Uri.EscapeDataString(metadata.PersistenceId)}-{metadata.SequenceNr.ToJournalRowKey()}";
+            return string.IsNullOrWhiteSpace(folders)
+                ? $"snapshot-{Uri.EscapeDataString(metadata.PersistenceId)}-{metadata.SequenceNr.ToJournalRowKey()}"
+                : $"{folders}/snapshot-{Uri.EscapeDataString(metadata.PersistenceId)}-{metadata.SequenceNr.ToJournalRowKey()}";
         }
 
         /// <summary>
         /// Used to help search for the most recent snapshot in Azure Blob storage.
         /// </summary>
         /// <param name="persistentId">The ID of the persistent entity.</param>
+        /// <param name="folders">Folder prefix added to the front of the file name</param>
         /// <returns>The prefix of a blob store search string.</returns>
-        public static string ToSnapshotSearchQuery(string persistentId)
+        public static string ToSnapshotSearchQuery(string persistentId, string folders)
         {
-            return $"snapshot-{Uri.EscapeDataString(persistentId)}";
+            return string.IsNullOrWhiteSpace(folders)
+                ? $"snapshot-{Uri.EscapeDataString(persistentId)}"
+                : $"{folders}/snapshot-{Uri.EscapeDataString(persistentId)}";
         }
     }
 }

--- a/src/Akka.Persistence.Azure/reference.conf
+++ b/src/Akka.Persistence.Azure/reference.conf
@@ -72,6 +72,15 @@ akka.persistence {
       # the name of the Windows Azure Blob Store container used to persist snapshots
       container-name = "akka-persistence-default-container"
   
+      # The "folder" or "directory" where snapshot files will be stored.
+      # Note that Azure Blob Storage does not implement a true folder tree structure,
+      # "folder" names are actually a simple prefix to the blob file name.
+      #
+      # Example:
+      # If you set this setting to "folder1/folder2", then the snapshots will be stored as:
+      #    /{account-name}/{container-name}/folder1/folder2/snapshot-{persistence-id}-{sequence-number}
+      folders = ""
+  
       #  Initial timeout to use when connecting to Azure Storage for the first time.
       connect-timeout = 3s
   


### PR DESCRIPTION
Related to https://github.com/akkadotnet/akka.net/issues/7510

Snapshots can now be stored in Azure Blob Storage "folders" by using the `AzureBlobSnapshotOptions.Folders` if you're using Akka.Hosting, or using the "akka.persistence.snapshot-store.azure-blob-store.folders" HOCON settings.