### PR TITLE
Fix missing (skipped) journal table spec

### DIFF
--- a/src/Akka.Persistence.Azure.Tests/AzureTableJournalSpec.cs
+++ b/src/Akka.Persistence.Azure.Tests/AzureTableJournalSpec.cs
@@ -15,7 +15,7 @@ using static Akka.Persistence.Azure.Tests.Helper.AzureStorageConfigHelper;
 namespace Akka.Persistence.Azure.Tests
 {
     [Collection("AzureSpecs")]
-    public abstract class AzureTableJournalSpec : JournalSpec
+    public class AzureTableJournalSpec : JournalSpec
     {
         public AzureTableJournalSpec(ITestOutputHelper output)
             : base(AzureConfig(), nameof(AzureTableJournalSpec), output)


### PR DESCRIPTION
Journal table spec was marked as abstract, it never ran before.