### PR TITLE
Cleanup legacy Akka.Persistence.Sql.Common (SQLite) code

### DIFF
--- a/src/Akka.Persistence.Azure/Journal/AzureTableStorageJournal.cs
+++ b/src/Akka.Persistence.Azure/Journal/AzureTableStorageJournal.cs
@@ -47,14 +47,10 @@ namespace Akka.Persistence.Azure.Journal
             { 0, TimeSpan.FromMilliseconds(8000) },
         };
 
-        private readonly HashSet<string> _allPersistenceIds = new HashSet<string>();
-        private readonly HashSet<IActorRef> _allPersistenceIdSubscribers = new HashSet<IActorRef>();
         private readonly ILoggingAdapter _log = Context.GetLogger();
-        private readonly Dictionary<string, ISet<IActorRef>> _persistenceIdSubscribers = new Dictionary<string, ISet<IActorRef>>();
         private readonly SerializationHelper _serialization;
         private readonly AzureTableStorageJournalSettings _settings;
         private readonly TableServiceClient _tableServiceClient;
-        private readonly Dictionary<string, ISet<IActorRef>> _tagSubscribers = new Dictionary<string, ISet<IActorRef>>();
         private readonly CancellationTokenSource _shutdownCts;
 
         public AzureTableStorageJournal(Config? config = null)
@@ -102,18 +98,10 @@ namespace Akka.Persistence.Azure.Journal
 
         public TableClient Table => _tableServiceClient.GetTableClient(_settings.TableName);
 
-        protected bool HasAllPersistenceIdSubscribers => _allPersistenceIdSubscribers.Count != 0;
-
-        protected bool HasPersistenceIdSubscribers => _persistenceIdSubscribers.Count != 0;
-
-        protected bool HasTagSubscribers => _tagSubscribers.Count != 0;
-
         public override async Task<long> ReadHighestSequenceNrAsync(
             string persistenceId,
             long fromSequenceNr)
         {
-            NotifyNewPersistenceIdAdded(persistenceId);
-
             _log.Debug("Entering method ReadHighestSequenceNrAsync");
 
             var seqNo = await HighestSequenceNumberQuery(persistenceId, null, _shutdownCts.Token)
@@ -133,8 +121,6 @@ namespace Akka.Persistence.Azure.Journal
             long max,
             Action<IPersistentRepresentation> recoveryCallback)
         {
-            NotifyNewPersistenceIdAdded(persistenceId);
-
             _log.Debug("Entering method ReplayMessagesAsync for persistentId [{0}] from seqNo range [{1}, {2}] and taking up to max [{3}]", 
                 persistenceId, fromSequenceNr, toSequenceNr, max);
 
@@ -212,8 +198,6 @@ namespace Akka.Persistence.Azure.Journal
 
         protected override async Task DeleteMessagesToAsync(string persistenceId, long toSequenceNr)
         {
-            NotifyNewPersistenceIdAdded(persistenceId);
-
             _log.Debug("Entering method DeleteMessagesToAsync for persistentId [{0}] and up to seqNo [{1}]", persistenceId, toSequenceNr);
 
             var pages = PersistentJournalEntryDeleteQuery(persistenceId, toSequenceNr, null, _shutdownCts.Token)
@@ -279,24 +263,13 @@ namespace Akka.Persistence.Azure.Journal
         {
             switch (message)
             {
+                case SelectCurrentPersistenceIds msg:
+                    GetAllPersistenceIds()
+                        .PipeTo(msg.ReplyTo, success: h => new CurrentPersistenceIds(h.Ids), failure: e => new Status.Failure(e));
+                    return true;
                 case ReplayTaggedMessages replay:
                     ReplayTaggedMessagesAsync(replay, _shutdownCts.Token)
                         .PipeTo(replay.ReplyTo, failure: e => new ReplayMessagesFailure(e));
-                    break;
-                case SubscribePersistenceId subscribe:
-                    AddPersistenceIdSubscriber(Sender, subscribe.PersistenceId);
-                    Context.Watch(Sender);
-                    break;
-                case SubscribeAllPersistenceIds _:
-                    var task = AddAllPersistenceIdSubscriber(Sender, _shutdownCts.Token); // Detached task
-                    Context.Watch(Sender);
-                    break;
-                case SubscribeTag subscribe:
-                    AddTagSubscriber(Sender, subscribe.Tag);
-                    Context.Watch(Sender);
-                    break;
-                case Terminated terminated:
-                    RemoveSubscriber(terminated.ActorRef);
                     break;
                 default:
                     return false;
@@ -326,7 +299,7 @@ namespace Akka.Persistence.Azure.Journal
                             var item = t;
                             Debug.Assert(item != null, nameof(item) + " != null");
 
-                            string[] tags = {};
+                            string[] tags = [];
                             // If the payload is a tagged payload, reset to a non-tagged payload
                             if (item!.Payload is Tagged tagged)
                             {
@@ -429,11 +402,6 @@ namespace Akka.Persistence.Azure.Journal
                         foreach (var r in allPersistenceResponse)
                             _log.Debug("Azure table storage wrote entity with status code [{0}]", r.Status);
 
-                    if (HasPersistenceIdSubscribers || HasAllPersistenceIdSubscribers)
-                    {
-                        highSequenceNumbers.ForEach(x => NotifyNewPersistenceIdAdded(x.Key));
-                    }
-
                     if (taggedEntries.Count > 0)
                     {
                         foreach (var kvp in taggedEntries)
@@ -456,14 +424,6 @@ namespace Akka.Persistence.Azure.Journal
                             if (_log.IsDebugEnabled && _settings.VerboseLogging)
                                 foreach (var r in eventTagsResponse)
                                     _log.Debug("Azure table storage wrote entity with status code [{0}]", r.Status);
-
-                            if (HasTagSubscribers && taggedEntries.Count != 0)
-                            {
-                                foreach (var tag in taggedEntries.Keys)
-                                {
-                                    NotifyTagChange(tag);
-                                }
-                            }
                         }
                     }
                 }
@@ -491,7 +451,7 @@ namespace Akka.Persistence.Azure.Journal
             return Table.QueryAsync<TableEntity>(
                 filter: $"PartitionKey eq '{AllPersistenceIdsEntry.PartitionKeyValue}'",
                 maxPerPage: maxPerPage,
-                @select: new[] { "RowKey" }, 
+                @select: ["RowKey"], 
                 cancellationToken: cancellationToken
             );
         }
@@ -575,40 +535,10 @@ namespace Akka.Persistence.Azure.Journal
                 cancellationToken: cancellationToken);
         }
 
-        private async Task AddAllPersistenceIdSubscriber(IActorRef subscriber, CancellationToken cancellationToken)
+        private async Task<(IEnumerable<string> Ids, long LastOrdering)> GetAllPersistenceIds(CancellationToken cancellationToken)
         {
-            lock (_allPersistenceIdSubscribers)
-            {
-                _allPersistenceIdSubscribers.Add(subscriber);
-            }
-            subscriber.Tell(new CurrentPersistenceIds(await GetAllPersistenceIds(cancellationToken)));
-        }
-
-        private void AddPersistenceIdSubscriber(IActorRef subscriber, string persistenceId)
-        {
-            if (!_persistenceIdSubscribers.TryGetValue(persistenceId, out var subscriptions))
-            {
-                subscriptions = new HashSet<IActorRef>();
-                _persistenceIdSubscribers.Add(persistenceId, subscriptions);
-            }
-
-            subscriptions.Add(subscriber);
-        }
-
-        private void AddTagSubscriber(IActorRef subscriber, string tag)
-        {
-            if (!_tagSubscribers.TryGetValue(tag, out var subscriptions))
-            {
-                subscriptions = new HashSet<IActorRef>();
-                _tagSubscribers.Add(tag, subscriptions);
-            }
-
-            subscriptions.Add(subscriber);
-        }
-
-        private async Task<IEnumerable<string>> GetAllPersistenceIds(CancellationToken cancellationToken)
-        {
-            return await GenerateAllPersistenceIdsQuery(null, cancellationToken)
+            var lastOrdering = HighestSequenceNumberQuery()
+            var ids = await GenerateAllPersistenceIdsQuery(null, cancellationToken)
                 .Select(item => item.RowKey).ToListAsync(cancellationToken);
         }
 
@@ -666,43 +596,6 @@ namespace Akka.Persistence.Azure.Journal
             return tables.Count > 0;
         }
 
-        private void NotifyNewPersistenceIdAdded(
-            string persistenceId)
-        {
-            var isNew = TryAddPersistenceId(persistenceId);
-            if (isNew && HasAllPersistenceIdSubscribers)
-            {
-                var added = new PersistenceIdAdded(persistenceId);
-                foreach (var subscriber in _allPersistenceIdSubscribers)
-                    subscriber.Tell(added);
-            }
-        }
-
-        private void NotifyTagChange(
-            string tag)
-        {
-            if (_tagSubscribers.TryGetValue(tag, out var subscribers))
-            {
-                var changed = new TaggedEventAppended(tag);
-                foreach (var subscriber in subscribers)
-                    subscriber.Tell(changed);
-            }
-        }
-
-        private void RemoveSubscriber(
-            IActorRef subscriber)
-        {
-            var pidSubscriptions = _persistenceIdSubscribers.Values.Where(x => x.Contains(subscriber));
-            foreach (var subscription in pidSubscriptions)
-                subscription.Remove(subscriber);
-
-            var tagSubscriptions = _tagSubscribers.Values.Where(x => x.Contains(subscriber));
-            foreach (var subscription in tagSubscriptions)
-                subscription.Remove(subscriber);
-
-            _allPersistenceIdSubscribers.Remove(subscriber);
-        }
-
         /// <summary>
         /// Replays all events with given tag within provided boundaries from current database.
         /// </summary>
@@ -756,14 +649,6 @@ namespace Akka.Persistence.Azure.Journal
             }
 
             return new ReplayTaggedMessageSuccess(true);
-        }
-
-        private bool TryAddPersistenceId(string persistenceId)
-        {
-            lock (_allPersistenceIds)
-            {
-                return _allPersistenceIds.Add(persistenceId);
-            }
         }
     }
 }

--- a/src/Akka.Persistence.Azure/Query/AzureTableStorageReadJournal.cs
+++ b/src/Akka.Persistence.Azure/Query/AzureTableStorageReadJournal.cs
@@ -10,8 +10,8 @@ using Akka.Configuration;
 using Akka.Persistence.Azure.Query.Publishers;
 using Akka.Persistence.Journal;
 using Akka.Persistence.Query;
-using Akka.Streams.Actors;
 using Akka.Streams.Dsl;
+using Reactive.Streams;
 
 namespace Akka.Persistence.Azure.Query
 {
@@ -27,8 +27,8 @@ namespace Akka.Persistence.Azure.Query
 
         private readonly int _maxBufferSize;
         private readonly TimeSpan _refreshInterval;
-        private readonly string _writeJournalPluginId;
-
+        private readonly IActorRef _journalRef;
+        
         /// <summary>
         /// Returns a default query configuration for akka persistence Azure-based journals and snapshot stores.
         /// </summary>
@@ -41,7 +41,7 @@ namespace Akka.Persistence.Azure.Query
         {
             _maxBufferSize = config.GetInt("max-buffer-size");
             _refreshInterval = config.GetTimeSpan("refresh-interval");
-            _writeJournalPluginId = config.GetString("write-plugin");
+            var writeJournalPluginId = config.GetString("write-plugin");
 
             var setupOption = system.Settings.Setup.Get<AzureTableStorageReadJournalSetup>();
             if (setupOption.HasValue)
@@ -52,8 +52,10 @@ namespace Akka.Persistence.Azure.Query
                 if (setup.RefreshInterval != null)
                     _refreshInterval = setup.RefreshInterval.Value;
                 if (!string.IsNullOrWhiteSpace(setup.WritePluginId))
-                    _writeJournalPluginId = setup.WritePluginId;
+                    writeJournalPluginId = setup.WritePluginId;
             }
+
+            _journalRef = Persistence.Instance.Apply(system).JournalFor(writeJournalPluginId);
         }
 
         /// <summary>
@@ -77,9 +79,9 @@ namespace Akka.Persistence.Azure.Query
         /// </para>
         /// </summary>
         public Source<string, NotUsed> PersistenceIds() =>
-            Source.ActorPublisher<string>(AllPersistenceIdsPublisher.Props(true, _writeJournalPluginId))
+            Source.ActorPublisher<string>(LivePersistenceIdsPublisher.Props(_refreshInterval, _journalRef))
                 .MapMaterializedValue(_ => NotUsed.Instance)
-                .Named("AllPersistenceIds") as Source<string, NotUsed>;
+                .Named("AllPersistenceIds");
 
         /// <summary>
         /// Same type of query as <see cref="PersistenceIds"/> but the stream
@@ -87,9 +89,9 @@ namespace Akka.Persistence.Azure.Query
         /// actors that are created after the query is completed are not included in the stream.
         /// </summary>
         public Source<string, NotUsed> CurrentPersistenceIds() =>
-            Source.ActorPublisher<string>(AllPersistenceIdsPublisher.Props(false, _writeJournalPluginId))
+            Source.ActorPublisher<string>(CurrentPersistenceIdsPublisher.Props(_journalRef))
                 .MapMaterializedValue(_ => NotUsed.Instance)
-                .Named("CurrentPersistenceIds") as Source<string, NotUsed>;
+                .Named("CurrentPersistenceIds");
 
         /// <summary>
         /// <see cref="EventsByPersistenceId"/> is used for retrieving events for a specific
@@ -118,9 +120,9 @@ namespace Akka.Persistence.Azure.Query
         /// backend journal.
         /// </summary>
         public Source<EventEnvelope, NotUsed> EventsByPersistenceId(string persistenceId, long fromSequenceNr, long toSequenceNr) =>
-            Source.ActorPublisher<EventEnvelope>(EventsByPersistenceIdPublisher.Props(persistenceId, fromSequenceNr, toSequenceNr, _refreshInterval, _maxBufferSize, _writeJournalPluginId))
+            Source.ActorPublisher<EventEnvelope>(EventsByPersistenceIdPublisher.Props(persistenceId, fromSequenceNr, toSequenceNr, _refreshInterval, _maxBufferSize, _journalRef))
                 .MapMaterializedValue(_ => NotUsed.Instance)
-                .Named("EventsByPersistenceId-" + persistenceId) as Source<EventEnvelope, NotUsed>;
+                .Named("EventsByPersistenceId-" + persistenceId);
 
         /// <summary>
         /// Same type of query as <see cref="EventsByPersistenceId"/> but the event stream
@@ -128,9 +130,9 @@ namespace Akka.Persistence.Azure.Query
         /// stored after the query is completed are not included in the event stream.
         /// </summary>
         public Source<EventEnvelope, NotUsed> CurrentEventsByPersistenceId(string persistenceId, long fromSequenceNr, long toSequenceNr) =>
-            Source.ActorPublisher<EventEnvelope>(EventsByPersistenceIdPublisher.Props(persistenceId, fromSequenceNr, toSequenceNr, null, _maxBufferSize, _writeJournalPluginId))
+            Source.ActorPublisher<EventEnvelope>(EventsByPersistenceIdPublisher.Props(persistenceId, fromSequenceNr, toSequenceNr, null, _maxBufferSize, _journalRef))
                 .MapMaterializedValue(_ => NotUsed.Instance)
-                .Named("CurrentEventsByPersistenceId-" + persistenceId) as Source<EventEnvelope, NotUsed>;
+                .Named("CurrentEventsByPersistenceId-" + persistenceId);
 
         /// <summary>
         /// <see cref="EventsByTag"/> is used for retrieving events that were marked with
@@ -173,11 +175,11 @@ namespace Akka.Persistence.Azure.Query
         /// </summary>
         public Source<EventEnvelope, NotUsed> EventsByTag(string tag, Offset offset = null)
         {
-            offset = offset ?? new Sequence(0L);
+            offset ??= new Sequence(0L);
             switch (offset)
             {
                 case Sequence seq:
-                    return Source.ActorPublisher<EventEnvelope>(EventsByTagPublisher.Props(tag, seq.Value, long.MaxValue, _refreshInterval, _maxBufferSize, _writeJournalPluginId))
+                    return Source.ActorPublisher<EventEnvelope>(EventsByTagPublisher.Props(tag, seq.Value, long.MaxValue, _refreshInterval, _maxBufferSize, _journalRef))
                         .MapMaterializedValue(_ => NotUsed.Instance)
                         .Named($"EventsByTag-{tag}");
                 case NoOffset _:
@@ -204,7 +206,7 @@ namespace Akka.Persistence.Azure.Query
             if(offset is not Sequence seq)
                 throw new ArgumentException($"{GetType().Name} does not support {offset.GetType().Name} offsets");
             
-            return Source.ActorPublisher<EventEnvelope>(EventsByTagPublisher.Props(tag, seq.Value, DateTime.UtcNow.Ticks, null, _maxBufferSize, _writeJournalPluginId))
+            return Source.ActorPublisher<EventEnvelope>(EventsByTagPublisher.Props(tag, seq.Value, DateTime.UtcNow.Ticks, null, _maxBufferSize, _journalRef))
                 .MapMaterializedValue(_ => NotUsed.Instance)
                 .Named($"CurrentEventsByTag-{tag}");
         }

--- a/src/Akka.Persistence.Azure/Query/Messages.cs
+++ b/src/Akka.Persistence.Azure/Query/Messages.cs
@@ -12,19 +12,21 @@ using System.Collections.Immutable;
 
 namespace Akka.Persistence.Azure.Query
 {
-    /// <summary>
-    /// When message implements this interface, it indicates that such message is EventJournal read subscription command.
-    /// </summary>
-    public interface ISubscriptionCommand { }
+    [Serializable]
+    public sealed class SelectCurrentPersistenceIds : IJournalRequest
+    {
+        public IActorRef ReplyTo { get; }
+        public long Offset { get; }
 
-    /// <summary>
-    /// TBD
-    /// </summary>
+        public SelectCurrentPersistenceIds(long offset, IActorRef replyTo)
+        {
+            Offset = offset;
+            ReplyTo = replyTo;
+        }
+    }
+
     public sealed class CurrentPersistenceIds : IDeadLetterSuppression
     {
-        /// <summary>
-        /// TBD
-        /// </summary>
         public readonly IEnumerable<string> AllPersistenceIds;
 
         /// <summary>
@@ -181,74 +183,7 @@ namespace Akka.Persistence.Azure.Query
 
         public bool Completed { get; }
     }
-
-    /// <summary>
-    /// Subscribe the `sender` to current and new persistenceIds.
-    /// Used by query-side. The journal will send one <see cref="CurrentPersistenceIds"/> to the
-    /// subscriber followed by <see cref="PersistenceIdAdded"/> messages when new persistenceIds
-    /// are created.
-    /// </summary>
-    public sealed class SubscribeAllPersistenceIds : ISubscriptionCommand
-    {
-        /// <summary>
-        /// TBD
-        /// </summary>
-        public static readonly SubscribeAllPersistenceIds Instance = new SubscribeAllPersistenceIds();
-
-        private SubscribeAllPersistenceIds()
-        {
-        }
-    }
-
-    /// <summary>
-    /// TBD
-    /// </summary>
-    /// <summary>
-    /// Subscribe the `sender` to changes (appended events) for a specific `persistenceId`.
-    /// Used by query-side. The journal will send <see cref="EventAppended"/> messages to
-    /// the subscriber when <see cref="AsyncWriteJournal.WriteMessagesAsync"/> has been called.
-    /// </summary>
-    public sealed class SubscribePersistenceId : ISubscriptionCommand
-    {
-        /// <summary>
-        /// TBD
-        /// </summary>
-        public readonly string PersistenceId;
-
-        /// <summary>
-        /// TBD
-        /// </summary>
-        /// <param name="persistenceId">TBD</param>
-        public SubscribePersistenceId(string persistenceId)
-        {
-            PersistenceId = persistenceId;
-        }
-    }
-
-    /// <summary>
-    /// Subscribe the `sender` to changes (appended events) for a specific `tag`.
-    /// Used by query-side. The journal will send <see cref="TaggedEventAppended"/> messages to
-    /// the subscriber when `asyncWriteMessages` has been called.
-    /// Events are tagged by wrapping in <see cref="Tagged"/>
-    /// via an <see cref="IEventAdapter"/>.
-    /// </summary>
-    public sealed class SubscribeTag : ISubscriptionCommand
-    {
-        /// <summary>
-        /// TBD
-        /// </summary>
-        public readonly string Tag;
-
-        /// <summary>
-        /// TBD
-        /// </summary>
-        /// <param name="tag">TBD</param>
-        public SubscribeTag(string tag)
-        {
-            Tag = tag;
-        }
-    }
-
+    
     /// <summary>
     /// TBD
     /// </summary>

--- a/src/Akka.Persistence.Azure/Query/Publishers/AbstractEventsByPersistenceIdPublisher.cs
+++ b/src/Akka.Persistence.Azure/Query/Publishers/AbstractEventsByPersistenceIdPublisher.cs
@@ -15,20 +15,19 @@ namespace Akka.Persistence.Azure.Query.Publishers
     {
         private ILoggingAdapter _log;
 
-        protected DeliveryBuffer<EventEnvelope> Buffer;
+        protected readonly DeliveryBuffer<EventEnvelope> Buffer;
         protected readonly IActorRef JournalRef;
         protected long CurrentSequenceNr;
 
-        protected AbstractEventsByPersistenceIdPublisher(string persistenceId, long fromSequenceNr, long toSequenceNr, int maxBufferSize, string writeJournalPluginId)
+        protected AbstractEventsByPersistenceIdPublisher(string persistenceId, long fromSequenceNr, long toSequenceNr, int maxBufferSize, IActorRef journalRef)
         {
             PersistenceId = persistenceId;
             CurrentSequenceNr = FromSequenceNr = fromSequenceNr;
             ToSequenceNr = toSequenceNr;
             MaxBufferSize = maxBufferSize;
-            WriteJournalPluginId = writeJournalPluginId;
             Buffer = new DeliveryBuffer<EventEnvelope>(OnNext);
 
-            JournalRef = Persistence.Instance.Apply(Context.System).JournalFor(writeJournalPluginId);
+            JournalRef = journalRef;
         }
 
         protected ILoggingAdapter Log => _log ?? (_log = Context.GetLogger());
@@ -36,7 +35,6 @@ namespace Akka.Persistence.Azure.Query.Publishers
         protected long FromSequenceNr { get; }
         protected long ToSequenceNr { get; set; }
         protected int MaxBufferSize { get; }
-        protected string WriteJournalPluginId { get; }
 
         protected bool IsTimeForReplay => (Buffer.IsEmpty || Buffer.Length <= MaxBufferSize / 2) && (CurrentSequenceNr <= ToSequenceNr);
 

--- a/src/Akka.Persistence.Azure/Query/Publishers/AbstractEventsByTagPublisher.cs
+++ b/src/Akka.Persistence.Azure/Query/Publishers/AbstractEventsByTagPublisher.cs
@@ -18,14 +18,13 @@ namespace Akka.Persistence.Azure.Query.Publishers
         protected readonly DeliveryBuffer<EventEnvelope> Buffer;
         protected readonly IActorRef JournalRef;
         protected long CurrentOffset;
-        protected AbstractEventsByTagPublisher(string tag, long fromOffset, int maxBufferSize, string writeJournalPluginId)
+        protected AbstractEventsByTagPublisher(string tag, long fromOffset, int maxBufferSize, IActorRef journalRef)
         {
             Tag = tag;
             CurrentOffset = FromOffset = fromOffset;
             MaxBufferSize = maxBufferSize;
-            WriteJournalPluginId = writeJournalPluginId;
             Buffer = new DeliveryBuffer<EventEnvelope>(OnNext);
-            JournalRef = Persistence.Instance.Apply(Context.System).JournalFor(writeJournalPluginId);
+            JournalRef = journalRef;
         }
 
         protected ILoggingAdapter Log => _log ??= Context.GetLogger();
@@ -33,7 +32,6 @@ namespace Akka.Persistence.Azure.Query.Publishers
         protected long FromOffset { get; }
         protected abstract long ToOffset { get; }
         protected int MaxBufferSize { get; }
-        protected string WriteJournalPluginId { get; }
 
         protected bool IsTimeForReplay => (Buffer.IsEmpty || Buffer.Length <= MaxBufferSize / 2) && (CurrentOffset <= ToOffset);
 

--- a/src/Akka.Persistence.Azure/Query/Publishers/AllPersistenceIdsPublisher.cs
+++ b/src/Akka.Persistence.Azure/Query/Publishers/AllPersistenceIdsPublisher.cs
@@ -4,27 +4,33 @@
 // </copyright>
 // -----------------------------------------------------------------------
 
+using System;
 using Akka.Actor;
+using Akka.Event;
+using Akka.Persistence.Journal;
 using Akka.Streams.Actors;
 
 namespace Akka.Persistence.Azure.Query.Publishers
 {
-    internal sealed class AllPersistenceIdsPublisher : ActorPublisher<string>
+        internal sealed class CurrentPersistenceIdsPublisher : ActorPublisher<string>, IWithUnboundedStash
     {
-        public static Props Props(bool liveQuery, string writeJournalPluginId)
+        public static Props Props(IActorRef writeJournal)
         {
-            return Actor.Props.Create(() => new AllPersistenceIdsPublisher(liveQuery, writeJournalPluginId));
+            return Actor.Props.Create(() => new CurrentPersistenceIdsPublisher(writeJournal));
         }
 
-        private readonly bool _liveQuery;
         private readonly IActorRef _journalRef;
-        private readonly DeliveryBuffer<string> _buffer;
 
-        public AllPersistenceIdsPublisher(bool liveQuery, string writeJournalPluginId)
+        private readonly DeliveryBuffer<string> _buffer;
+        private readonly ILoggingAdapter _log;
+
+        public IStash Stash { get; set; }
+
+        public CurrentPersistenceIdsPublisher(IActorRef journalRef)
         {
-            _liveQuery = liveQuery;
+            _journalRef = journalRef;
             _buffer = new DeliveryBuffer<string>(OnNext);
-            _journalRef = Persistence.Instance.Apply(Context.System).JournalFor(writeJournalPluginId);
+            _log = Context.GetLogger();
         }
 
         protected override bool Receive(object message)
@@ -32,8 +38,10 @@ namespace Akka.Persistence.Azure.Query.Publishers
             switch (message)
             {
                 case Request _:
-                    _journalRef.Tell(SubscribeAllPersistenceIds.Instance);
-                    Become(Active);
+                    Become(Initializing);
+                    _journalRef
+                        .Ask<CurrentPersistenceIds>(new MemoryJournal.SelectCurrentPersistenceIds(0, Self))
+                        .PipeTo(Self);
                     return true;
                 
                 case Cancel _:
@@ -45,7 +53,7 @@ namespace Akka.Persistence.Azure.Query.Publishers
             }
         }
 
-        private bool Active(object message)
+        private bool Initializing(object message)
         {
             switch (message)
             {
@@ -53,26 +61,188 @@ namespace Akka.Persistence.Azure.Query.Publishers
                     _buffer.AddRange(current.AllPersistenceIds);
                     _buffer.DeliverBuffer(TotalDemand);
 
-                    if (!_liveQuery && _buffer.IsEmpty)
+                    if (_buffer.IsEmpty)
+                    {
                         OnCompleteThenStop();
+                        return true;
+                    }
+
+                    Become(Active);
+                    Stash.UnstashAll();
                     return true;
                 
-                case PersistenceIdAdded added:
-                    if (_liveQuery)
+                case Cancel _:
+                    Context.Stop(Self);
+                    return true;
+                
+                case Status.Failure msg:
+                    if (msg.Cause is AskTimeoutException e)
                     {
-                        _buffer.Add(added.PersistenceId);
-                        _buffer.DeliverBuffer(TotalDemand);
+                        _log.Info(e, "Current persistence id query timed out, retrying");
                     }
+                    else
+                    {
+                        _log.Info(msg.Cause, "Current persistence id query failed, retrying");
+                    }
+                    return true;
+                    
+                default:
+                    Stash.Stash();
+                    return true;
+            }
+        }
+
+        private bool Active(object message)
+        {
+            switch (message)
+            {
+                case CurrentPersistenceIds _:
+                    // Ignore duplicate CurrentPersistenceIds response
                     return true;
                 
                 case Request _:
                     _buffer.DeliverBuffer(TotalDemand);
-                    if (!_liveQuery && _buffer.IsEmpty)
+                    if (_buffer.IsEmpty)
                         OnCompleteThenStop();
                     return true;
                 
                 case Cancel _:
                     Context.Stop(Self);
+                    return true;
+                
+                default:
+                    return false;
+            }
+        }
+    }
+
+    internal sealed class LivePersistenceIdsPublisher : ActorPublisher<string>, IWithUnboundedStash, IWithTimers
+    {
+        private sealed class Continue
+        {
+            public static readonly Continue Instance = new();
+
+            private Continue() { }
+        }
+
+        public static Props Props(TimeSpan refreshInterval, IActorRef writeJournal)
+        {
+            return Actor.Props.Create(() => new LivePersistenceIdsPublisher(refreshInterval, writeJournal));
+        }
+
+        private long _lastOrderingOffset = 0L;
+        private readonly TimeSpan _refreshInterval;
+        private readonly IActorRef _journalRef;
+        private readonly DeliveryBuffer<string> _buffer;
+        private readonly ILoggingAdapter _log;
+
+        public IStash Stash { get; set; } = null!;
+        public ITimerScheduler Timers { get; set; } = null!;
+
+        public LivePersistenceIdsPublisher(TimeSpan refreshInterval, IActorRef journalRef)
+        {
+            _journalRef = journalRef;
+            _log = Context.GetLogger();
+            _refreshInterval = refreshInterval;
+            _buffer = new DeliveryBuffer<string>(OnNext);
+        }
+
+        protected override void PreStart()
+        {
+            base.PreStart();
+            Timers.StartPeriodicTimer(Continue.Instance, Continue.Instance, _refreshInterval, _refreshInterval, Self);
+        }
+
+        protected override void PostStop()
+        {
+            Timers.CancelAll();
+            base.PostStop();
+        }
+
+        protected override bool Receive(object message)
+        {
+            switch (message)
+            {
+                case Request _:
+                    Become(Waiting);
+                    _journalRef
+                        .Ask<CurrentPersistenceIds>(new SelectCurrentPersistenceIds(_lastOrderingOffset, Self))
+                        .PipeTo(Self);
+                    return true;
+                
+                case Continue _:
+                    return true;
+                
+                case Cancel _:
+                    Context.Stop(Self);
+                    return true;
+                
+                default:
+                    return false;
+            }
+        }
+
+        private bool Waiting(object message)
+        {
+            switch (message)
+            {
+                case CurrentPersistenceIds current:
+                    _lastOrderingOffset = current.HighestOrderingNumber;
+                    _buffer.AddRange(current.AllPersistenceIds);
+                    _buffer.DeliverBuffer(TotalDemand);
+
+                    Become(Active);
+                    Stash.UnstashAll();
+                    return true;
+                
+                case Continue _:
+                    return true;
+                
+                case Cancel _:
+                    Context.Stop(Self);
+                    return true;
+                
+                case Status.Failure msg:
+                    if (msg.Cause is AskTimeoutException e)
+                    {
+                        _log.Info(e, $"Current persistence id query timed out, retrying. Offset: {_lastOrderingOffset}");
+                    }
+                    else
+                    {
+                        _log.Info(msg.Cause, $"Current persistence id query failed, retrying. Offset: {_lastOrderingOffset}");
+                    }
+                    
+                    Become(Active);
+                    Stash.UnstashAll();
+                    return true;
+                    
+                default:
+                    Stash.Stash();
+                    return true;
+            }
+        }
+
+        private bool Active(object message)
+        {
+            switch (message)
+            {
+                case CurrentPersistenceIds _:
+                    // Ignore duplicate CurrentPersistenceIds response
+                    return true;
+                
+                case Request _:
+                    _buffer.DeliverBuffer(TotalDemand);
+                    return true;
+                
+                case Continue _:
+                    return true;
+                
+                case Cancel _:
+                    Context.Stop(Self);
+                    return true;
+                
+                case Status.Failure msg:
+                    _log.Info(msg.Cause, "Unexpected failure received");
                     return true;
                 
                 default:

--- a/src/Akka.Persistence.Azure/Query/Publishers/CurrentEventsByPersistenceIdPublisher.cs
+++ b/src/Akka.Persistence.Azure/Query/Publishers/CurrentEventsByPersistenceIdPublisher.cs
@@ -10,8 +10,8 @@ namespace Akka.Persistence.Azure.Query.Publishers
 {
     internal sealed class CurrentEventsByPersistenceIdPublisher : AbstractEventsByPersistenceIdPublisher
     {
-        public CurrentEventsByPersistenceIdPublisher(string persistenceId, long fromSequenceNr, long toSequenceNr, int maxBufferSize, string writeJournalPluginId)
-            : base(persistenceId, fromSequenceNr, toSequenceNr, maxBufferSize, writeJournalPluginId)
+        public CurrentEventsByPersistenceIdPublisher(string persistenceId, long fromSequenceNr, long toSequenceNr, int maxBufferSize, IActorRef journalRef)
+            : base(persistenceId, fromSequenceNr, toSequenceNr, maxBufferSize, journalRef)
         {
         }
 

--- a/src/Akka.Persistence.Azure/Query/Publishers/CurrentEventsByTagPublisher.cs
+++ b/src/Akka.Persistence.Azure/Query/Publishers/CurrentEventsByTagPublisher.cs
@@ -18,8 +18,8 @@ namespace Akka.Persistence.Azure.Query.Publishers
             long fromOffset, 
             long toOffset, 
             int maxBufferSize, 
-            string writeJournalPluginId)
-            : base(tag, fromOffset, maxBufferSize, writeJournalPluginId)
+            IActorRef journalRef)
+            : base(tag, fromOffset, maxBufferSize, journalRef)
         {
             ToOffset = toOffset;
         }

--- a/src/Akka.Persistence.Azure/Query/Publishers/EventsByPersistenceIdPublisher.cs
+++ b/src/Akka.Persistence.Azure/Query/Publishers/EventsByPersistenceIdPublisher.cs
@@ -20,11 +20,11 @@ namespace Akka.Persistence.Azure.Query.Publishers
             }
         }
 
-        public static Props Props(string persistenceId, long fromSequenceNr, long toSequenceNr, TimeSpan? refreshDuration, int maxBufferSize, string writeJournalPluginId)
+        public static Props Props(string persistenceId, long fromSequenceNr, long toSequenceNr, TimeSpan? refreshDuration, int maxBufferSize, IActorRef journalRef)
         {
             return refreshDuration.HasValue
-                ? Actor.Props.Create(() => new LiveEventsByPersistenceIdPublisher(persistenceId, fromSequenceNr, toSequenceNr, maxBufferSize, writeJournalPluginId, refreshDuration.Value))
-                : Actor.Props.Create(() => new CurrentEventsByPersistenceIdPublisher(persistenceId, fromSequenceNr, toSequenceNr, maxBufferSize, writeJournalPluginId));
+                ? Actor.Props.Create(() => new LiveEventsByPersistenceIdPublisher(persistenceId, fromSequenceNr, toSequenceNr, maxBufferSize, journalRef, refreshDuration.Value))
+                : Actor.Props.Create(() => new CurrentEventsByPersistenceIdPublisher(persistenceId, fromSequenceNr, toSequenceNr, maxBufferSize, journalRef));
         }
     }
 }

--- a/src/Akka.Persistence.Azure/Query/Publishers/EventsByTagPublisher.cs
+++ b/src/Akka.Persistence.Azure/Query/Publishers/EventsByTagPublisher.cs
@@ -20,11 +20,11 @@ namespace Akka.Persistence.Azure.Query.Publishers
             }
         }
 
-        public static Props Props(string tag, long fromOffset, long toOffset, TimeSpan? refreshInterval, int maxBufferSize, string writeJournalPluginId)
+        public static Props Props(string tag, long fromOffset, long toOffset, TimeSpan? refreshInterval, int maxBufferSize, IActorRef journalRef)
         {
             return refreshInterval.HasValue
-                ? Actor.Props.Create(() => new LiveEventsByTagPublisher(tag, fromOffset, toOffset, refreshInterval.Value, maxBufferSize, writeJournalPluginId))
-                : Actor.Props.Create(() => new CurrentEventsByTagPublisher(tag, fromOffset, toOffset, maxBufferSize, writeJournalPluginId));
+                ? Actor.Props.Create(() => new LiveEventsByTagPublisher(tag, fromOffset, toOffset, refreshInterval.Value, maxBufferSize, journalRef))
+                : Actor.Props.Create(() => new CurrentEventsByTagPublisher(tag, fromOffset, toOffset, maxBufferSize, journalRef));
         }
     }
 }

--- a/src/Akka.Persistence.Azure/Query/Publishers/LiveEventsByPersistenceIdPublisher.cs
+++ b/src/Akka.Persistence.Azure/Query/Publishers/LiveEventsByPersistenceIdPublisher.cs
@@ -13,8 +13,8 @@ namespace Akka.Persistence.Azure.Query.Publishers
     {
         private readonly ICancelable _tickCancelable;
 
-        public LiveEventsByPersistenceIdPublisher(string persistenceId, long fromSequenceNr, long toSequenceNr, int maxBufferSize, string writeJournalPluginId, TimeSpan refreshInterval)
-            : base(persistenceId, fromSequenceNr, toSequenceNr, maxBufferSize, writeJournalPluginId)
+        public LiveEventsByPersistenceIdPublisher(string persistenceId, long fromSequenceNr, long toSequenceNr, int maxBufferSize, IActorRef journalRef, TimeSpan refreshInterval)
+            : base(persistenceId, fromSequenceNr, toSequenceNr, maxBufferSize, journalRef)
         {
             _tickCancelable = Context.System.Scheduler.ScheduleTellRepeatedlyCancelable(refreshInterval, refreshInterval, Self, EventsByPersistenceIdPublisher.Continue.Instance, Self);
         }
@@ -27,7 +27,6 @@ namespace Akka.Persistence.Azure.Query.Publishers
 
         protected override void ReceiveInitialRequest()
         {
-            JournalRef.Tell(new SubscribePersistenceId(PersistenceId));
             Replay();
         }
 

--- a/src/Akka.Persistence.Azure/Query/Publishers/LiveEventsByTagPublisher.cs
+++ b/src/Akka.Persistence.Azure/Query/Publishers/LiveEventsByTagPublisher.cs
@@ -19,8 +19,8 @@ namespace Akka.Persistence.Azure.Query.Publishers
             long toOffset, 
             TimeSpan refreshInterval, 
             int maxBufferSize, 
-            string writeJournalPluginId)
-            : base(tag, fromOffset, maxBufferSize, writeJournalPluginId)
+            IActorRef journalRef)
+            : base(tag, fromOffset, maxBufferSize, journalRef)
         {
             ToOffset = toOffset;
             _tickCancelable = Context.System.Scheduler.ScheduleTellRepeatedlyCancelable(refreshInterval, refreshInterval, Self, EventsByTagPublisher.Continue.Instance, Self);
@@ -36,7 +36,6 @@ namespace Akka.Persistence.Azure.Query.Publishers
 
         protected override void ReceiveInitialRequest()
         {
-            JournalRef.Tell(new SubscribeTag(Tag));
             Replay();
         }
 


### PR DESCRIPTION
Current problems:
* There's no ordering number to support live query, need to replace it with timestamp.