### PR TITLE
Update RELEASE_NOTES.md for 1.5.44 release

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,9 @@
+#### 1.5.44 June 26th 2025 ####
+
+* [Update Akka.NET v1.5.44](https://github.com/akkadotnet/akka.net/releases/tag/1.5.44)
+* [Update Akka.Hosting v1.5.44](https://github.com/akkadotnet/Akka.Hosting/releases/tag/1.5.44)
+* [Fix `CancellationTokenSource` memory leak](https://github.com/petabridge/Akka.Persistence.Azure/pull/519)
+
 #### 1.5.42 May 22nd 2025 ####
 
 * [Update Akka.NET v1.5.42](https://github.com/akkadotnet/akka.net/releases/tag/1.5.42)


### PR DESCRIPTION
## 1.5.44 June 26th 2025

* [Update Akka.NET v1.5.44](https://github.com/akkadotnet/akka.net/releases/tag/1.5.44)
* [Update Akka.Hosting v1.5.44](https://github.com/akkadotnet/Akka.Hosting/releases/tag/1.5.44)
* [Fix `CancellationTokenSource` memory leak](https://github.com/petabridge/Akka.Persistence.Azure/pull/519)