### PR TITLE
Fix Microsoft.Identity.Client documentation security bug

### DIFF
--- a/src/Akka.Persistence.Azure/Akka.Persistence.Azure.csproj
+++ b/src/Akka.Persistence.Azure/Akka.Persistence.Azure.csproj
@@ -16,6 +16,8 @@
     <PackageReference Include="Azure.Identity" />
     <PackageReference Include="Azure.Storage.Blobs" />
     <PackageReference Include="System.Linq.Async" />
+    <!-- Needed to fix Microsoft.Identity.Client typosquatting phishing link bug (https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/pull/5278) -->
+    <PackageReference Include="Microsoft.Identity.Client" />
   </ItemGroup>
 
 </Project>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -13,6 +13,8 @@
     <PackageVersion Include="System.Linq.Async" Version="6.0.1" />
     <PackageVersion Include="Akka.Persistence.Hosting" Version="$(AkkaHostingVersion)" />
     <PackageVersion Include="Akka.Cluster.Hosting" Version="$(AkkaHostingVersion)" />
+    <!-- Needed to fix Microsoft.Identity.Client typosquatting phishing link bug (https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/pull/5278) -->
+    <PackageVersion Include="Microsoft.Identity.Client" Version="4.73.1" />
   </ItemGroup>
   <!-- Test dependencies -->
   <ItemGroup>


### PR DESCRIPTION
## Changes

* Add explicit reference to the newest Microsoft.Identity.Client package due to https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/pull/5278

Apparently, the typo URL is being typosquatted by a phishing site and is a security risk.