### PR TITLE
Update RELEASE_NOTES.md for 1.5.51 release

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,9 @@
+#### 1.5.51 October 1st 2025 ####
+
+* [Update Akka.NET v1.5.51](https://github.com/akkadotnet/akka.net/releases/tag/1.5.51)
+* [Update Akka.Hosting v1.5.51](https://github.com/akkadotnet/Akka.Hosting/releases/tag/1.5.51)
+* [Fix obsolete WithJournal API usage in Akka.Hosting extension](https://github.com/petabridge/Akka.Persistence.Azure/pull/529)
+
 #### 1.5.49 September 15th 2025 ####
 
 * [Update Akka.NET v1.5.49](https://github.com/akkadotnet/akka.net/releases/tag/1.5.45)

--- a/src/Directory.Generated.props
+++ b/src/Directory.Generated.props
@@ -1,7 +1,8 @@
 <Project>
   <PropertyGroup>
-    <VersionPrefix>1.5.26</VersionPrefix>
-    <PackageReleaseNotes>[Update Akka.NET v1.5.26](https://github.com/akkadotnet/akka.net/releases/tag/1.5.26)
-[Update Akka.Hosting v1.5.25](https://github.com/akkadotnet/Akka.Hosting/releases/tag/1.5.25)</PackageReleaseNotes>
+    <VersionPrefix>1.5.51</VersionPrefix>
+    <PackageReleaseNotes>* [Update Akka.NET v1.5.51](https://github.com/akkadotnet/akka.net/releases/tag/1.5.51)
+* [Update Akka.Hosting v1.5.51](https://github.com/akkadotnet/Akka.Hosting/releases/tag/1.5.51)
+* [Fix obsolete WithJournal API usage in Akka.Hosting extension](https://github.com/petabridge/Akka.Persistence.Azure/pull/529)</PackageReleaseNotes>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
## Summary
Release notes for Akka.Persistence.Azure v1.5.51

## Changes
- Updated Akka.NET to v1.5.51
- Updated Akka.Hosting to v1.5.51
- Fixed obsolete WithJournal API usage in Akka.Hosting extension

See RELEASE_NOTES.md for full details.