### PR TITLE
Release 1.5.51.1

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,15 @@
+#### 1.5.51.1 October 2nd 2025 ####
+
+* [Update Akka.Hosting v1.5.51.1](https://github.com/akkadotnet/Akka.Hosting/releases/tag/1.5.51.1)
+* [Fix Akka.Persistence.Azure.Hosting health checks and adopt unified API](https://github.com/petabridge/Akka.Persistence.Azure/pull/531)
+
+This patch release fixes critical issues in the Akka.Persistence.Azure.Hosting extension methods:
+
+- Health checks are now properly registered for both journal and snapshot store
+- Snapshot store health check support added via `Action<AkkaPersistenceSnapshotBuilder>` parameters
+- Migrated from manual HOCON manipulation to the unified Akka.Hosting API (`.WithJournal()` and `.WithSnapshot()`)
+- All changes are backward compatible with no breaking changes
+
 #### 1.5.51 October 1st 2025 ####
 
 * [Update Akka.NET v1.5.51](https://github.com/akkadotnet/akka.net/releases/tag/1.5.51)

--- a/src/Directory.Generated.props
+++ b/src/Directory.Generated.props
@@ -1,8 +1,14 @@
 <Project>
   <PropertyGroup>
-    <VersionPrefix>1.5.51</VersionPrefix>
-    <PackageReleaseNotes>* [Update Akka.NET v1.5.51](https://github.com/akkadotnet/akka.net/releases/tag/1.5.51)
-* [Update Akka.Hosting v1.5.51](https://github.com/akkadotnet/Akka.Hosting/releases/tag/1.5.51)
-* [Fix obsolete WithJournal API usage in Akka.Hosting extension](https://github.com/petabridge/Akka.Persistence.Azure/pull/529)</PackageReleaseNotes>
+    <VersionPrefix>1.5.51.1</VersionPrefix>
+    <PackageReleaseNotes>* [Update Akka.Hosting v1.5.51.1](https://github.com/akkadotnet/Akka.Hosting/releases/tag/1.5.51.1)
+* [Fix Akka.Persistence.Azure.Hosting health checks and adopt unified API](https://github.com/petabridge/Akka.Persistence.Azure/pull/531)
+
+This patch release fixes critical issues in the Akka.Persistence.Azure.Hosting extension methods:
+
+- Health checks are now properly registered for both journal and snapshot store
+- Snapshot store health check support added via `Action&lt;AkkaPersistenceSnapshotBuilder&gt;` parameters
+- Migrated from manual HOCON manipulation to the unified Akka.Hosting API (`.WithJournal()` and `.WithSnapshot()`)
+- All changes are backward compatible with no breaking changes</PackageReleaseNotes>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
## Summary

Prepare release 1.5.51.1 which fixes critical issues in the Akka.Persistence.Azure.Hosting extension methods.

## Changes

- Update RELEASE_NOTES.md for version 1.5.51.1
- Update Directory.Generated.props with new version and release notes
- Fix health checks registration for both journal and snapshot store
- Add snapshot store health check support via `Action<AkkaPersistenceSnapshotBuilder>` parameters
- Migrate from manual HOCON manipulation to unified Akka.Hosting API (`.WithJournal()` and `.WithSnapshot()`)

## Test Plan

- [ ] Verify build completes successfully
- [ ] Verify all tests pass
- [ ] Confirm version numbers are correct in generated files
- [ ] Validate release notes formatting and content