### PR TITLE
Update RELEASE_NOTES.md for 1.5.53 release

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,8 @@
+#### 1.5.53 October 16th 2025 ####
+
+* [Update Akka.NET v1.5.53](https://github.com/akkadotnet/akka.net/releases/tag/1.5.53)
+* [Update Akka.Hosting v1.5.53](https://github.com/akkadotnet/Akka.Hosting/releases/tag/1.5.53)
+
 #### 1.5.51.1 October 2nd 2025 ####
 
 * [Update Akka.Hosting v1.5.51.1](https://github.com/akkadotnet/Akka.Hosting/releases/tag/1.5.51.1)

--- a/src/Directory.Generated.props
+++ b/src/Directory.Generated.props
@@ -1,14 +1,7 @@
 <Project>
   <PropertyGroup>
-    <VersionPrefix>1.5.51.1</VersionPrefix>
-    <PackageReleaseNotes>* [Update Akka.Hosting v1.5.51.1](https://github.com/akkadotnet/Akka.Hosting/releases/tag/1.5.51.1)
-* [Fix Akka.Persistence.Azure.Hosting health checks and adopt unified API](https://github.com/petabridge/Akka.Persistence.Azure/pull/531)
-
-This patch release fixes critical issues in the Akka.Persistence.Azure.Hosting extension methods:
-
-- Health checks are now properly registered for both journal and snapshot store
-- Snapshot store health check support added via `Action&lt;AkkaPersistenceSnapshotBuilder&gt;` parameters
-- Migrated from manual HOCON manipulation to the unified Akka.Hosting API (`.WithJournal()` and `.WithSnapshot()`)
-- All changes are backward compatible with no breaking changes</PackageReleaseNotes>
+    <VersionPrefix>1.5.53</VersionPrefix>
+    <PackageReleaseNotes>* [Update Akka.NET v1.5.53](https://github.com/akkadotnet/akka.net/releases/tag/1.5.53)
+* [Update Akka.Hosting v1.5.53](https://github.com/akkadotnet/Akka.Hosting/releases/tag/1.5.53)</PackageReleaseNotes>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
## Summary

- Updated RELEASE_NOTES.md with version 1.5.53 entry
- Updated version metadata via build script
- Bumped Akka.NET and Akka.Hosting to v1.5.53

## Changes

* [Update Akka.NET v1.5.53](https://github.com/akkadotnet/akka.net/releases/tag/1.5.53)
* [Update Akka.Hosting v1.5.53](https://github.com/akkadotnet/Akka.Hosting/releases/tag/1.5.53)