### PR TITLE
Add connectivity health checks for Azure persistence backends

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,11 @@ return host;
 
 ### Health Checks (Akka.Persistence.Azure.Hosting v1.5.51.1+)
 
-Starting with v1.5.51.1, you can enable health checks for Azure Table Storage journal and Blob Storage snapshots:
+Starting with v1.5.51.1, you can enable health checks for Azure Table Storage journal and Blob Storage snapshots.
+
+#### Standard Health Checks
+
+The standard health checks monitor the persistence plugins themselves and report their status:
 
 ```csharp
 builder.WithAzurePersistence(
@@ -152,6 +156,61 @@ builder.WithAzurePersistence(
     journalBuilder: journal => journal.WithHealthCheck(),
     snapshotBuilder: snapshot => snapshot.WithHealthCheck());
 ```
+
+#### Connectivity Health Checks (v1.5.55+)
+
+Starting with v1.5.55, you can enable proactive connectivity health checks that verify Azure backend connectivity regardless of recent operation activity. This helps detect database outages during idle periods.
+
+**Using Akka.Hosting 1.5.55.1 or later:**
+
+```csharp
+var journalOptions = new AzureTableStorageJournalOptions(isDefault: true)
+{
+    ConnectionString = connectionString,
+    TableName = "akkajournal",
+    AutoInitialize = true
+};
+
+var snapshotOptions = new AzureBlobSnapshotOptions(isDefault: true)
+{
+    ConnectionString = connectionString,
+    ContainerName = "akka-snapshots",
+    AutoInitialize = true
+};
+
+builder
+    .WithAzureTableJournal(journalOptions, journal =>
+    {
+        journal.WithConnectivityCheck(); // Proactively verify Azure Table Storage connectivity
+    })
+    .WithAzureBlobsSnapshotStore(snapshotOptions, snapshot =>
+    {
+        snapshot.WithConnectivityCheck(); // Proactively verify Azure Blob Storage connectivity
+    });
+```
+
+**Combining Standard and Connectivity Health Checks:**
+
+You can enable both types of health checks for comprehensive monitoring:
+
+```csharp
+builder
+    .WithAzureTableJournal(journalOptions, journal =>
+    {
+        journal.WithHealthCheck();           // Monitor plugin status
+        journal.WithConnectivityCheck();     // Verify backend connectivity
+    })
+    .WithAzureBlobsSnapshotStore(snapshotOptions, snapshot =>
+    {
+        snapshot.WithHealthCheck();          // Monitor plugin status
+        snapshot.WithConnectivityCheck();    // Verify backend connectivity
+    });
+```
+
+The connectivity checks support all Azure SDK connection methods:
+- Connection strings
+- ServiceUri + TokenCredential (e.g., DefaultAzureCredential)
+- Factory methods for TableServiceClient and BlobServiceClient
 
 For more information on Akka.NET health checks, see the [Akka.Hosting health check documentation](https://github.com/akkadotnet/Akka.Hosting#health-checks).
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,7 +1,7 @@
 #### 1.5.55 October 27 2025 ####
 
 * [Update Akka.NET v1.5.55](https://github.com/akkadotnet/akka.net/releases/tag/1.5.55)
-* [Update Akka.Hosting v1.5.55](https://github.com/akkadotnet/Akka.Hosting/releases/tag/1.5.55)
+* [Update Akka.Hosting v1.5.55.1](https://github.com/akkadotnet/Akka.Hosting/releases/tag/1.5.55.1)
 * [Add connectivity health checks for Azure persistence backends](https://github.com/petabridge/Akka.Persistence.Azure/pull/TBD)
 
 This release adds proactive connectivity health checks for Azure persistence backends, implementing the feature requested in [Akka.Hosting#678](https://github.com/akkadotnet/Akka.Hosting/issues/678).
@@ -9,6 +9,10 @@ This release adds proactive connectivity health checks for Azure persistence bac
 **New Features:**
 
 Connectivity checks are now available for both Azure Table Storage journal and Azure Blob Storage snapshot store. These are opt-in health checks that proactively verify backend connectivity regardless of recent operation activity, helping detect database outages during idle periods.
+
+**Improved API:**
+
+With Akka.Hosting 1.5.55.1, the connectivity check API has been simplified. Options are now automatically accessed from the builder, eliminating redundant parameter passing.
 
 **Usage Example:**
 
@@ -30,15 +34,19 @@ var snapshotOptions = new AzureBlobSnapshotOptions(isDefault: true)
 builder
     .WithAzureTableJournal(journalOptions, journal =>
     {
-        journal.WithConnectivityCheck(journalOptions);
+        journal.WithConnectivityCheck(); // Simplified API!
     })
     .WithAzureBlobsSnapshotStore(snapshotOptions, snapshot =>
     {
-        snapshot.WithConnectivityCheck(snapshotOptions);
+        snapshot.WithConnectivityCheck(); // Simplified API!
     });
 ```
 
 The connectivity checks support all Azure SDK connection methods (connection string, ServiceUri + TokenCredential, and factory methods) and include proper tagging for filtering in health check endpoints.
+
+**Backward Compatibility:**
+
+The old API signature (passing options explicitly) is still supported for backward compatibility with older versions of Akka.Hosting.
 
 #### 1.5.51.1 October 2nd 2025 ####
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,45 @@
+#### 1.5.55 October 27 2025 ####
+
+* [Update Akka.NET v1.5.55](https://github.com/akkadotnet/akka.net/releases/tag/1.5.55)
+* [Update Akka.Hosting v1.5.55](https://github.com/akkadotnet/Akka.Hosting/releases/tag/1.5.55)
+* [Add connectivity health checks for Azure persistence backends](https://github.com/petabridge/Akka.Persistence.Azure/pull/TBD)
+
+This release adds proactive connectivity health checks for Azure persistence backends, implementing the feature requested in [Akka.Hosting#678](https://github.com/akkadotnet/Akka.Hosting/issues/678).
+
+**New Features:**
+
+Connectivity checks are now available for both Azure Table Storage journal and Azure Blob Storage snapshot store. These are opt-in health checks that proactively verify backend connectivity regardless of recent operation activity, helping detect database outages during idle periods.
+
+**Usage Example:**
+
+```csharp
+var journalOptions = new AzureTableStorageJournalOptions(isDefault: true)
+{
+    ConnectionString = connectionString,
+    TableName = "akkajournal",
+    AutoInitialize = true
+};
+
+var snapshotOptions = new AzureBlobSnapshotOptions(isDefault: true)
+{
+    ConnectionString = connectionString,
+    ContainerName = "akka-snapshots",
+    AutoInitialize = true
+};
+
+builder
+    .WithAzureTableJournal(journalOptions, journal =>
+    {
+        journal.WithConnectivityCheck(journalOptions);
+    })
+    .WithAzureBlobsSnapshotStore(snapshotOptions, snapshot =>
+    {
+        snapshot.WithConnectivityCheck(snapshotOptions);
+    });
+```
+
+The connectivity checks support all Azure SDK connection methods (connection string, ServiceUri + TokenCredential, and factory methods) and include proper tagging for filtering in health check endpoints.
+
 #### 1.5.51.1 October 2nd 2025 ####
 
 * [Update Akka.Hosting v1.5.51.1](https://github.com/akkadotnet/Akka.Hosting/releases/tag/1.5.51.1)

--- a/src/Akka.Persistence.Azure.API.Tests/verify/ApiSpecs.ApproveCore.DotNet.verified.txt
+++ b/src/Akka.Persistence.Azure.API.Tests/verify/ApiSpecs.ApproveCore.DotNet.verified.txt
@@ -85,6 +85,7 @@ namespace Akka.Persistence.Azure.Journal
         public bool VerboseLogging { get; }
         public static Akka.Persistence.Azure.Journal.AzureTableStorageJournalSettings Create(Akka.Actor.ActorSystem system) { }
         public static Akka.Persistence.Azure.Journal.AzureTableStorageJournalSettings Create(Akka.Configuration.Config config) { }
+        public Azure.Data.Tables.TableServiceClient CreateTableServiceClient() { }
         public Akka.Persistence.Azure.Journal.AzureTableStorageJournalSettings WithAutoInitialize(bool autoInitialize) { }
         public Akka.Persistence.Azure.Journal.AzureTableStorageJournalSettings WithAzureCredential(System.Uri serviceUri, Azure.Core.TokenCredential defaultAzureCredential, [System.Runtime.CompilerServices.NullableAttribute(2)] Azure.Data.Tables.TableClientOptions tableClientOptions = null) { }
         public Akka.Persistence.Azure.Journal.AzureTableStorageJournalSettings WithConnectTimeout(System.TimeSpan connectTimeout) { }
@@ -316,6 +317,7 @@ namespace Akka.Persistence.Azure.Snapshot
         public bool VerboseLogging { get; }
         public static Akka.Persistence.Azure.Snapshot.AzureBlobSnapshotStoreSettings Create(Akka.Actor.ActorSystem system) { }
         public static Akka.Persistence.Azure.Snapshot.AzureBlobSnapshotStoreSettings Create(Akka.Configuration.Config config) { }
+        public Azure.Storage.Blobs.BlobServiceClient CreateBlobServiceClient() { }
         public static string SanitizeFolder([System.Runtime.CompilerServices.NullableAttribute(2)] string folder) { }
         public Akka.Persistence.Azure.Snapshot.AzureBlobSnapshotStoreSettings WithAutoInitialize(bool autoInitialize) { }
         public Akka.Persistence.Azure.Snapshot.AzureBlobSnapshotStoreSettings WithAzureCredential(System.Uri serviceUri, Azure.Core.TokenCredential defaultAzureCredential, [System.Runtime.CompilerServices.NullableAttribute(2)] Azure.Storage.Blobs.BlobClientOptions blobClientOption = null) { }

--- a/src/Akka.Persistence.Azure.API.Tests/verify/ApiSpecs.ApproveHosting.DotNet.verified.txt
+++ b/src/Akka.Persistence.Azure.API.Tests/verify/ApiSpecs.ApproveHosting.DotNet.verified.txt
@@ -29,6 +29,30 @@ namespace Akka.Persistence.Azure.Hosting
         protected override System.Text.StringBuilder Build(System.Text.StringBuilder sb) { }
     }
     [System.Runtime.CompilerServices.NullableAttribute(0)]
+    public sealed class AzureBlobSnapshotStoreConnectivityCheck : Akka.Hosting.IAkkaHealthCheck
+    {
+        public AzureBlobSnapshotStoreConnectivityCheck(string connectionString, System.Uri serviceUri, Azure.Core.TokenCredential azureCredential, Azure.Storage.Blobs.BlobClientOptions blobClientOptions, [System.Runtime.CompilerServices.NullableAttribute(new byte[] {
+                2,
+                1})] System.Func<Azure.Storage.Blobs.BlobServiceClient> blobServiceClientFactory, [System.Runtime.CompilerServices.NullableAttribute(1)] string snapshotStoreId) { }
+        public System.Threading.Tasks.Task<Microsoft.Extensions.Diagnostics.HealthChecks.HealthCheckResult> CheckHealthAsync(Akka.Hosting.AkkaHealthCheckContext context, System.Threading.CancellationToken cancellationToken = null) { }
+    }
+    [System.Runtime.CompilerServices.NullableAttribute(0)]
+    public class static AzureConnectivityCheckExtensions
+    {
+        public static Akka.Persistence.Hosting.AkkaPersistenceJournalBuilder WithConnectivityCheck(this Akka.Persistence.Hosting.AkkaPersistenceJournalBuilder builder, Microsoft.Extensions.Diagnostics.HealthChecks.HealthStatus unHealthyStatus = 0, [System.Runtime.CompilerServices.NullableAttribute(2)] string name = null, [System.Runtime.CompilerServices.NullableAttribute(new byte[] {
+                2,
+                1})] string[] tags = null) { }
+        public static Akka.Persistence.Hosting.AkkaPersistenceJournalBuilder WithConnectivityCheck(this Akka.Persistence.Hosting.AkkaPersistenceJournalBuilder builder, Akka.Persistence.Azure.Hosting.AzureTableStorageJournalOptions journalOptions, Microsoft.Extensions.Diagnostics.HealthChecks.HealthStatus unHealthyStatus = 0, [System.Runtime.CompilerServices.NullableAttribute(2)] string name = null, [System.Runtime.CompilerServices.NullableAttribute(new byte[] {
+                2,
+                1})] string[] tags = null) { }
+        public static Akka.Persistence.Hosting.AkkaPersistenceSnapshotBuilder WithConnectivityCheck(this Akka.Persistence.Hosting.AkkaPersistenceSnapshotBuilder builder, Microsoft.Extensions.Diagnostics.HealthChecks.HealthStatus unHealthyStatus = 0, [System.Runtime.CompilerServices.NullableAttribute(2)] string name = null, [System.Runtime.CompilerServices.NullableAttribute(new byte[] {
+                2,
+                1})] string[] tags = null) { }
+        public static Akka.Persistence.Hosting.AkkaPersistenceSnapshotBuilder WithConnectivityCheck(this Akka.Persistence.Hosting.AkkaPersistenceSnapshotBuilder builder, Akka.Persistence.Azure.Hosting.AzureBlobSnapshotOptions snapshotOptions, Microsoft.Extensions.Diagnostics.HealthChecks.HealthStatus unHealthyStatus = 0, [System.Runtime.CompilerServices.NullableAttribute(2)] string name = null, [System.Runtime.CompilerServices.NullableAttribute(new byte[] {
+                2,
+                1})] string[] tags = null) { }
+    }
+    [System.Runtime.CompilerServices.NullableAttribute(0)]
     public class static AzurePersistenceExtensions
     {
         public const string DefaultBlobContainerName = "akka-persistence-default-container";
@@ -80,6 +104,14 @@ namespace Akka.Persistence.Azure.Hosting
         public static Akka.Hosting.AkkaConfigurationBuilder WithAzureTableJournal(this Akka.Hosting.AkkaConfigurationBuilder builder, Akka.Persistence.Azure.Hosting.AzureTableStorageJournalOptions options, [System.Runtime.CompilerServices.NullableAttribute(new byte[] {
                 2,
                 1})] System.Action<Akka.Persistence.Hosting.AkkaPersistenceJournalBuilder> journalBuilder) { }
+    }
+    [System.Runtime.CompilerServices.NullableAttribute(0)]
+    public sealed class AzureTableJournalConnectivityCheck : Akka.Hosting.IAkkaHealthCheck
+    {
+        public AzureTableJournalConnectivityCheck(string connectionString, System.Uri serviceUri, Azure.Core.TokenCredential azureCredential, Azure.Data.Tables.TableClientOptions tableClientOptions, [System.Runtime.CompilerServices.NullableAttribute(new byte[] {
+                2,
+                1})] System.Func<Azure.Data.Tables.TableServiceClient> tableServiceClientFactory, [System.Runtime.CompilerServices.NullableAttribute(1)] string journalId) { }
+        public System.Threading.Tasks.Task<Microsoft.Extensions.Diagnostics.HealthChecks.HealthCheckResult> CheckHealthAsync(Akka.Hosting.AkkaHealthCheckContext context, System.Threading.CancellationToken cancellationToken = null) { }
     }
     [System.Runtime.CompilerServices.NullableAttribute(0)]
     public sealed class AzureTableStorageJournalOptions : Akka.Persistence.Hosting.JournalOptions

--- a/src/Akka.Persistence.Azure.Hosting/AzureBlobSnapshotStoreConnectivityCheck.cs
+++ b/src/Akka.Persistence.Azure.Hosting/AzureBlobSnapshotStoreConnectivityCheck.cs
@@ -1,0 +1,89 @@
+// -----------------------------------------------------------------------
+// <copyright file="AzureBlobSnapshotStoreConnectivityCheck.cs" company="Petabridge, LLC">
+//      Copyright (C) 2015 - 2023 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Akka.Hosting;
+using Azure.Core;
+using Azure.Storage.Blobs;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+#nullable enable
+namespace Akka.Persistence.Azure.Hosting
+{
+    /// <summary>
+    /// Health check that verifies connectivity to the Azure Blob Storage instance used by the snapshot store.
+    /// This is a liveness check that proactively verifies backend connectivity.
+    /// </summary>
+    public sealed class AzureBlobSnapshotStoreConnectivityCheck : IAkkaHealthCheck
+    {
+        private readonly string? _connectionString;
+        private readonly Uri? _serviceUri;
+        private readonly TokenCredential? _azureCredential;
+        private readonly BlobClientOptions? _blobClientOptions;
+        private readonly Func<BlobServiceClient>? _blobServiceClientFactory;
+        private readonly string _snapshotStoreId;
+
+        public AzureBlobSnapshotStoreConnectivityCheck(
+            string? connectionString,
+            Uri? serviceUri,
+            TokenCredential? azureCredential,
+            BlobClientOptions? blobClientOptions,
+            Func<BlobServiceClient>? blobServiceClientFactory,
+            string snapshotStoreId)
+        {
+            _connectionString = connectionString;
+            _serviceUri = serviceUri;
+            _azureCredential = azureCredential;
+            _blobClientOptions = blobClientOptions;
+            _blobServiceClientFactory = blobServiceClientFactory;
+            _snapshotStoreId = snapshotStoreId ?? throw new ArgumentNullException(nameof(snapshotStoreId));
+        }
+
+        public async Task<HealthCheckResult> CheckHealthAsync(
+            AkkaHealthCheckContext context,
+            CancellationToken cancellationToken = default)
+        {
+            try
+            {
+                BlobServiceClient client;
+
+                // Priority: Factory > ConnectionString > ServiceUri + Credential
+                if (_blobServiceClientFactory != null)
+                {
+                    client = _blobServiceClientFactory();
+                }
+                else if (!string.IsNullOrWhiteSpace(_connectionString))
+                {
+                    client = new BlobServiceClient(_connectionString, _blobClientOptions);
+                }
+                else if (_serviceUri != null && _azureCredential != null)
+                {
+                    client = new BlobServiceClient(_serviceUri, _azureCredential, _blobClientOptions);
+                }
+                else
+                {
+                    return HealthCheckResult.Unhealthy(
+                        $"Azure Blob snapshot store '{_snapshotStoreId}' connectivity check failed: no valid connection configuration provided");
+                }
+
+                // Perform a lightweight connectivity check
+                await client.GetPropertiesAsync(cancellationToken);
+
+                return HealthCheckResult.Healthy($"Azure Blob snapshot store '{_snapshotStoreId}' connection successful");
+            }
+            catch (OperationCanceledException)
+            {
+                return HealthCheckResult.Unhealthy($"Azure Blob snapshot store '{_snapshotStoreId}' connectivity check timed out");
+            }
+            catch (Exception ex)
+            {
+                return HealthCheckResult.Unhealthy($"Azure Blob snapshot store '{_snapshotStoreId}' connection failed", ex);
+            }
+        }
+    }
+}

--- a/src/Akka.Persistence.Azure.Hosting/AzureBlobSnapshotStoreConnectivityCheck.cs
+++ b/src/Akka.Persistence.Azure.Hosting/AzureBlobSnapshotStoreConnectivityCheck.cs
@@ -52,18 +52,22 @@ namespace Akka.Persistence.Azure.Hosting
             {
                 BlobServiceClient client;
 
-                // Priority: Factory > ConnectionString > ServiceUri + Credential
+                // Priority: Factory > ServiceUri + Credential > ConnectionString
+                // This matches the priority order in AzureBlobSnapshotStore
                 if (_blobServiceClientFactory != null)
                 {
                     client = _blobServiceClientFactory();
                 }
-                else if (!string.IsNullOrWhiteSpace(_connectionString))
-                {
-                    client = new BlobServiceClient(_connectionString, _blobClientOptions);
-                }
                 else if (_serviceUri != null && _azureCredential != null)
                 {
-                    client = new BlobServiceClient(_serviceUri, _azureCredential, _blobClientOptions);
+                    client = new BlobServiceClient(
+                        serviceUri: _serviceUri,
+                        credential: _azureCredential,
+                        options: _blobClientOptions);
+                }
+                else if (!string.IsNullOrWhiteSpace(_connectionString))
+                {
+                    client = new BlobServiceClient(_connectionString);
                 }
                 else
                 {

--- a/src/Akka.Persistence.Azure.Hosting/AzureConnectivityCheckExtensions.cs
+++ b/src/Akka.Persistence.Azure.Hosting/AzureConnectivityCheckExtensions.cs
@@ -1,0 +1,106 @@
+// -----------------------------------------------------------------------
+// <copyright file="AzureConnectivityCheckExtensions.cs" company="Petabridge, LLC">
+//      Copyright (C) 2015 - 2023 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System;
+using Akka.Hosting;
+using Akka.Persistence.Hosting;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+#nullable enable
+namespace Akka.Persistence.Azure.Hosting
+{
+    /// <summary>
+    /// Extension methods for Azure persistence connectivity checks
+    /// </summary>
+    public static class AzureConnectivityCheckExtensions
+    {
+        /// <summary>
+        /// Adds a connectivity check for the Azure Table Storage journal.
+        /// This is a liveness check that proactively verifies database connectivity.
+        /// </summary>
+        /// <param name="builder">The journal builder</param>
+        /// <param name="journalOptions">The journal options containing connection details</param>
+        /// <param name="unHealthyStatus">The status to return when check fails. Defaults to Unhealthy.</param>
+        /// <param name="name">Optional name for the health check. Defaults to "Akka.Persistence.Azure.Journal.{id}.Connectivity"</param>
+        /// <param name="tags">Optional tags for the health check. Defaults to ["akka", "persistence", "azure", "journal", "connectivity"]</param>
+        /// <returns>The journal builder for chaining</returns>
+        public static AkkaPersistenceJournalBuilder WithConnectivityCheck(
+            this AkkaPersistenceJournalBuilder builder,
+            AzureTableStorageJournalOptions journalOptions,
+            HealthStatus unHealthyStatus = HealthStatus.Unhealthy,
+            string? name = null,
+            string[]? tags = null)
+        {
+            if (journalOptions is null)
+                throw new ArgumentNullException(nameof(journalOptions));
+
+            if (string.IsNullOrWhiteSpace(journalOptions.ConnectionString)
+                && journalOptions.ServiceUri is null
+                && journalOptions.TableServiceClientFactory is null)
+                throw new ArgumentException(
+                    "At least one of ConnectionString, ServiceUri, or TableServiceClientFactory must be set on AzureTableStorageJournalOptions",
+                    nameof(journalOptions));
+
+            var registration = new AkkaHealthCheckRegistration(
+                name ?? $"Akka.Persistence.Azure.Journal.{journalOptions.Identifier}.Connectivity",
+                new AzureTableJournalConnectivityCheck(
+                    journalOptions.ConnectionString,
+                    journalOptions.ServiceUri,
+                    journalOptions.AzureCredential,
+                    journalOptions.TableClientOptions,
+                    journalOptions.TableServiceClientFactory,
+                    journalOptions.Identifier),
+                unHealthyStatus,
+                tags ?? new[] { "akka", "persistence", "azure", "journal", "connectivity" });
+
+            // Use the new WithCustomHealthCheck method from Akka.Hosting 1.5.55
+            return builder.WithCustomHealthCheck(registration);
+        }
+
+        /// <summary>
+        /// Adds a connectivity check for the Azure Blob Storage snapshot store.
+        /// This is a liveness check that proactively verifies database connectivity.
+        /// </summary>
+        /// <param name="builder">The snapshot builder</param>
+        /// <param name="snapshotOptions">The snapshot options containing connection details</param>
+        /// <param name="unHealthyStatus">The status to return when check fails. Defaults to Unhealthy.</param>
+        /// <param name="name">Optional name for the health check. Defaults to "Akka.Persistence.Azure.SnapshotStore.{id}.Connectivity"</param>
+        /// <param name="tags">Optional tags for the health check. Defaults to ["akka", "persistence", "azure", "snapshot-store", "connectivity"]</param>
+        /// <returns>The snapshot builder for chaining</returns>
+        public static AkkaPersistenceSnapshotBuilder WithConnectivityCheck(
+            this AkkaPersistenceSnapshotBuilder builder,
+            AzureBlobSnapshotOptions snapshotOptions,
+            HealthStatus unHealthyStatus = HealthStatus.Unhealthy,
+            string? name = null,
+            string[]? tags = null)
+        {
+            if (snapshotOptions is null)
+                throw new ArgumentNullException(nameof(snapshotOptions));
+
+            if (string.IsNullOrWhiteSpace(snapshotOptions.ConnectionString)
+                && snapshotOptions.ServiceUri is null
+                && snapshotOptions.BlobServiceClientFactory is null)
+                throw new ArgumentException(
+                    "At least one of ConnectionString, ServiceUri, or BlobServiceClientFactory must be set on AzureBlobSnapshotOptions",
+                    nameof(snapshotOptions));
+
+            var registration = new AkkaHealthCheckRegistration(
+                name ?? $"Akka.Persistence.Azure.SnapshotStore.{snapshotOptions.Identifier}.Connectivity",
+                new AzureBlobSnapshotStoreConnectivityCheck(
+                    snapshotOptions.ConnectionString,
+                    snapshotOptions.ServiceUri,
+                    snapshotOptions.AzureCredential,
+                    snapshotOptions.BlobClientOptions,
+                    snapshotOptions.BlobServiceClientFactory,
+                    snapshotOptions.Identifier),
+                unHealthyStatus,
+                tags ?? new[] { "akka", "persistence", "azure", "snapshot-store", "connectivity" });
+
+            // Use the new WithCustomHealthCheck method from Akka.Hosting 1.5.55
+            return builder.WithCustomHealthCheck(registration);
+        }
+    }
+}

--- a/src/Akka.Persistence.Azure.Hosting/AzureConnectivityCheckExtensions.cs
+++ b/src/Akka.Persistence.Azure.Hosting/AzureConnectivityCheckExtensions.cs
@@ -22,11 +22,43 @@ namespace Akka.Persistence.Azure.Hosting
         /// This is a liveness check that proactively verifies database connectivity.
         /// </summary>
         /// <param name="builder">The journal builder</param>
+        /// <param name="unHealthyStatus">The status to return when check fails. Defaults to Unhealthy.</param>
+        /// <param name="name">Optional name for the health check. Defaults to "Akka.Persistence.Azure.Journal.{id}.Connectivity"</param>
+        /// <param name="tags">Optional tags for the health check. Defaults to ["akka", "persistence", "azure", "journal", "connectivity"]</param>
+        /// <returns>The journal builder for chaining</returns>
+        /// <remarks>
+        /// Requires Akka.Hosting 1.5.55.1 or later. Options are accessed from builder.Options automatically.
+        /// </remarks>
+        public static AkkaPersistenceJournalBuilder WithConnectivityCheck(
+            this AkkaPersistenceJournalBuilder builder,
+            HealthStatus unHealthyStatus = HealthStatus.Unhealthy,
+            string? name = null,
+            string[]? tags = null)
+        {
+            if (!(builder.Options is AzureTableStorageJournalOptions journalOptions))
+            {
+                throw new InvalidOperationException(
+                    "WithConnectivityCheck requires AzureTableStorageJournalOptions. " +
+                    "Ensure you're using this with WithAzureTableJournal() or pass options explicitly using the overload.");
+            }
+
+            return WithConnectivityCheck(builder, journalOptions, unHealthyStatus, name, tags);
+        }
+
+        /// <summary>
+        /// Adds a connectivity check for the Azure Table Storage journal.
+        /// This is a liveness check that proactively verifies database connectivity.
+        /// </summary>
+        /// <param name="builder">The journal builder</param>
         /// <param name="journalOptions">The journal options containing connection details</param>
         /// <param name="unHealthyStatus">The status to return when check fails. Defaults to Unhealthy.</param>
         /// <param name="name">Optional name for the health check. Defaults to "Akka.Persistence.Azure.Journal.{id}.Connectivity"</param>
         /// <param name="tags">Optional tags for the health check. Defaults to ["akka", "persistence", "azure", "journal", "connectivity"]</param>
         /// <returns>The journal builder for chaining</returns>
+        /// <remarks>
+        /// This overload is provided for backward compatibility. Consider using the parameterless overload
+        /// if you're on Akka.Hosting 1.5.55.1 or later.
+        /// </remarks>
         public static AkkaPersistenceJournalBuilder WithConnectivityCheck(
             this AkkaPersistenceJournalBuilder builder,
             AzureTableStorageJournalOptions journalOptions,
@@ -65,11 +97,43 @@ namespace Akka.Persistence.Azure.Hosting
         /// This is a liveness check that proactively verifies database connectivity.
         /// </summary>
         /// <param name="builder">The snapshot builder</param>
+        /// <param name="unHealthyStatus">The status to return when check fails. Defaults to Unhealthy.</param>
+        /// <param name="name">Optional name for the health check. Defaults to "Akka.Persistence.Azure.SnapshotStore.{id}.Connectivity"</param>
+        /// <param name="tags">Optional tags for the health check. Defaults to ["akka", "persistence", "azure", "snapshot-store", "connectivity"]</param>
+        /// <returns>The snapshot builder for chaining</returns>
+        /// <remarks>
+        /// Requires Akka.Hosting 1.5.55.1 or later. Options are accessed from builder.Options automatically.
+        /// </remarks>
+        public static AkkaPersistenceSnapshotBuilder WithConnectivityCheck(
+            this AkkaPersistenceSnapshotBuilder builder,
+            HealthStatus unHealthyStatus = HealthStatus.Unhealthy,
+            string? name = null,
+            string[]? tags = null)
+        {
+            if (!(builder.Options is AzureBlobSnapshotOptions snapshotOptions))
+            {
+                throw new InvalidOperationException(
+                    "WithConnectivityCheck requires AzureBlobSnapshotOptions. " +
+                    "Ensure you're using this with WithAzureBlobsSnapshotStore() or pass options explicitly using the overload.");
+            }
+
+            return WithConnectivityCheck(builder, snapshotOptions, unHealthyStatus, name, tags);
+        }
+
+        /// <summary>
+        /// Adds a connectivity check for the Azure Blob Storage snapshot store.
+        /// This is a liveness check that proactively verifies database connectivity.
+        /// </summary>
+        /// <param name="builder">The snapshot builder</param>
         /// <param name="snapshotOptions">The snapshot options containing connection details</param>
         /// <param name="unHealthyStatus">The status to return when check fails. Defaults to Unhealthy.</param>
         /// <param name="name">Optional name for the health check. Defaults to "Akka.Persistence.Azure.SnapshotStore.{id}.Connectivity"</param>
         /// <param name="tags">Optional tags for the health check. Defaults to ["akka", "persistence", "azure", "snapshot-store", "connectivity"]</param>
         /// <returns>The snapshot builder for chaining</returns>
+        /// <remarks>
+        /// This overload is provided for backward compatibility. Consider using the parameterless overload
+        /// if you're on Akka.Hosting 1.5.55.1 or later.
+        /// </remarks>
         public static AkkaPersistenceSnapshotBuilder WithConnectivityCheck(
             this AkkaPersistenceSnapshotBuilder builder,
             AzureBlobSnapshotOptions snapshotOptions,

--- a/src/Akka.Persistence.Azure.Hosting/AzureTableJournalConnectivityCheck.cs
+++ b/src/Akka.Persistence.Azure.Hosting/AzureTableJournalConnectivityCheck.cs
@@ -52,18 +52,22 @@ namespace Akka.Persistence.Azure.Hosting
             {
                 TableServiceClient client;
 
-                // Priority: Factory > ConnectionString > ServiceUri + Credential
+                // Priority: Factory > ServiceUri + Credential > ConnectionString
+                // This matches the priority order in AzureTableStorageJournal
                 if (_tableServiceClientFactory != null)
                 {
                     client = _tableServiceClientFactory();
                 }
-                else if (!string.IsNullOrWhiteSpace(_connectionString))
-                {
-                    client = new TableServiceClient(_connectionString, _tableClientOptions);
-                }
                 else if (_serviceUri != null && _azureCredential != null)
                 {
-                    client = new TableServiceClient(_serviceUri, _azureCredential, _tableClientOptions);
+                    client = new TableServiceClient(
+                        endpoint: _serviceUri,
+                        tokenCredential: _azureCredential,
+                        options: _tableClientOptions);
+                }
+                else if (!string.IsNullOrWhiteSpace(_connectionString))
+                {
+                    client = new TableServiceClient(_connectionString);
                 }
                 else
                 {

--- a/src/Akka.Persistence.Azure.Hosting/AzureTableJournalConnectivityCheck.cs
+++ b/src/Akka.Persistence.Azure.Hosting/AzureTableJournalConnectivityCheck.cs
@@ -1,0 +1,89 @@
+// -----------------------------------------------------------------------
+// <copyright file="AzureTableJournalConnectivityCheck.cs" company="Petabridge, LLC">
+//      Copyright (C) 2015 - 2023 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Akka.Hosting;
+using Azure.Core;
+using Azure.Data.Tables;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+#nullable enable
+namespace Akka.Persistence.Azure.Hosting
+{
+    /// <summary>
+    /// Health check that verifies connectivity to the Azure Table Storage instance used by the journal.
+    /// This is a liveness check that proactively verifies backend connectivity.
+    /// </summary>
+    public sealed class AzureTableJournalConnectivityCheck : IAkkaHealthCheck
+    {
+        private readonly string? _connectionString;
+        private readonly Uri? _serviceUri;
+        private readonly TokenCredential? _azureCredential;
+        private readonly TableClientOptions? _tableClientOptions;
+        private readonly Func<TableServiceClient>? _tableServiceClientFactory;
+        private readonly string _journalId;
+
+        public AzureTableJournalConnectivityCheck(
+            string? connectionString,
+            Uri? serviceUri,
+            TokenCredential? azureCredential,
+            TableClientOptions? tableClientOptions,
+            Func<TableServiceClient>? tableServiceClientFactory,
+            string journalId)
+        {
+            _connectionString = connectionString;
+            _serviceUri = serviceUri;
+            _azureCredential = azureCredential;
+            _tableClientOptions = tableClientOptions;
+            _tableServiceClientFactory = tableServiceClientFactory;
+            _journalId = journalId ?? throw new ArgumentNullException(nameof(journalId));
+        }
+
+        public async Task<HealthCheckResult> CheckHealthAsync(
+            AkkaHealthCheckContext context,
+            CancellationToken cancellationToken = default)
+        {
+            try
+            {
+                TableServiceClient client;
+
+                // Priority: Factory > ConnectionString > ServiceUri + Credential
+                if (_tableServiceClientFactory != null)
+                {
+                    client = _tableServiceClientFactory();
+                }
+                else if (!string.IsNullOrWhiteSpace(_connectionString))
+                {
+                    client = new TableServiceClient(_connectionString, _tableClientOptions);
+                }
+                else if (_serviceUri != null && _azureCredential != null)
+                {
+                    client = new TableServiceClient(_serviceUri, _azureCredential, _tableClientOptions);
+                }
+                else
+                {
+                    return HealthCheckResult.Unhealthy(
+                        $"Azure Table journal '{_journalId}' connectivity check failed: no valid connection configuration provided");
+                }
+
+                // Perform a lightweight connectivity check
+                await client.GetPropertiesAsync(cancellationToken);
+
+                return HealthCheckResult.Healthy($"Azure Table journal '{_journalId}' connection successful");
+            }
+            catch (OperationCanceledException)
+            {
+                return HealthCheckResult.Unhealthy($"Azure Table journal '{_journalId}' connectivity check timed out");
+            }
+            catch (Exception ex)
+            {
+                return HealthCheckResult.Unhealthy($"Azure Table journal '{_journalId}' connection failed", ex);
+            }
+        }
+    }
+}

--- a/src/Akka.Persistence.Azure.Tests/Hosting/AzureConnectivityCheckSpec.cs
+++ b/src/Akka.Persistence.Azure.Tests/Hosting/AzureConnectivityCheckSpec.cs
@@ -1,0 +1,298 @@
+// -----------------------------------------------------------------------
+// <copyright file="AzureConnectivityCheckSpec.cs" company="Petabridge, LLC">
+//      Copyright (C) 2015 - 2023 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Akka.Hosting;
+using Akka.Persistence.Azure.Hosting;
+using Akka.Persistence.Azure.Tests.Helper;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Hosting;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Akka.Persistence.Azure.Tests.Hosting
+{
+    /// <summary>
+    /// Tests for Azure persistence connectivity health checks.
+    /// Validates that connectivity checks can detect both healthy and unhealthy Azure connections.
+    /// </summary>
+    [Collection("AzureSpecs")]
+    public class AzureConnectivityCheckSpec : Akka.Hosting.TestKit.TestKit
+    {
+        private readonly string _connectionString;
+
+        public AzureConnectivityCheckSpec(AzuriteFixture fixture, ITestOutputHelper output)
+            : base(nameof(AzureConnectivityCheckSpec), output)
+        {
+            _connectionString = fixture.ConnectionString;
+        }
+
+        protected override void ConfigureServices(HostBuilderContext context, IServiceCollection services)
+        {
+            base.ConfigureServices(context, services);
+            services.AddHealthChecks();
+        }
+
+        protected override void ConfigureAkka(AkkaConfigurationBuilder builder, IServiceProvider provider)
+        {
+            var journalOptions = new AzureTableStorageJournalOptions(isDefault: true)
+            {
+                ConnectionString = _connectionString,
+                TableName = "connectivitytest",
+                AutoInitialize = true
+            };
+
+            var snapshotOptions = new AzureBlobSnapshotOptions(isDefault: true)
+            {
+                ConnectionString = _connectionString,
+                ContainerName = "connectivity-test-snapshots",
+                AutoInitialize = true
+            };
+
+            builder
+                .WithAzureTableJournal(journalOptions, journal =>
+                {
+                    journal.WithConnectivityCheck(journalOptions);
+                })
+                .WithAzureBlobsSnapshotStore(snapshotOptions, snapshot =>
+                {
+                    snapshot.WithConnectivityCheck(snapshotOptions);
+                });
+        }
+
+        [Fact]
+        public async Task Journal_connectivity_check_should_be_registered()
+        {
+            // Arrange
+            var healthCheckService = Host.Services.GetRequiredService<HealthCheckService>();
+
+            // Act
+            var result = await healthCheckService.CheckHealthAsync();
+
+            // Assert
+            result.Entries.Keys.Should().Contain(key => key.Contains("Journal") && key.Contains("Connectivity"));
+        }
+
+        [Fact]
+        public async Task Snapshot_connectivity_check_should_be_registered()
+        {
+            // Arrange
+            var healthCheckService = Host.Services.GetRequiredService<HealthCheckService>();
+
+            // Act
+            var result = await healthCheckService.CheckHealthAsync();
+
+            // Assert
+            result.Entries.Keys.Should().Contain(key => key.Contains("SnapshotStore") && key.Contains("Connectivity"));
+        }
+
+        [Fact]
+        public async Task Journal_connectivity_check_should_report_healthy_with_valid_connection()
+        {
+            // Arrange
+            var healthCheckService = Host.Services.GetRequiredService<HealthCheckService>();
+
+            // Act
+            var result = await healthCheckService.CheckHealthAsync();
+
+            // Assert
+            var journalCheck = result.Entries.First(e => e.Key.Contains("Journal") && e.Key.Contains("Connectivity"));
+            journalCheck.Value.Status.Should().Be(HealthStatus.Healthy);
+            journalCheck.Value.Description.Should().Contain("connection successful");
+
+            Output?.WriteLine($"Journal connectivity check: {journalCheck.Key}");
+            Output?.WriteLine($"Status: {journalCheck.Value.Status}");
+            Output?.WriteLine($"Description: {journalCheck.Value.Description}");
+        }
+
+        [Fact]
+        public async Task Snapshot_connectivity_check_should_report_healthy_with_valid_connection()
+        {
+            // Arrange
+            var healthCheckService = Host.Services.GetRequiredService<HealthCheckService>();
+
+            // Act
+            var result = await healthCheckService.CheckHealthAsync();
+
+            // Assert
+            var snapshotCheck = result.Entries.First(e => e.Key.Contains("SnapshotStore") && e.Key.Contains("Connectivity"));
+            snapshotCheck.Value.Status.Should().Be(HealthStatus.Healthy);
+            snapshotCheck.Value.Description.Should().Contain("connection successful");
+
+            Output?.WriteLine($"Snapshot connectivity check: {snapshotCheck.Key}");
+            Output?.WriteLine($"Status: {snapshotCheck.Value.Status}");
+            Output?.WriteLine($"Description: {snapshotCheck.Value.Description}");
+        }
+
+        [Fact]
+        public async Task Both_connectivity_checks_should_be_healthy()
+        {
+            // Arrange
+            var healthCheckService = Host.Services.GetRequiredService<HealthCheckService>();
+
+            // Act
+            var result = await healthCheckService.CheckHealthAsync();
+
+            // Assert
+            var connectivityChecks = result.Entries
+                .Where(e => e.Key.Contains("Connectivity"))
+                .ToList();
+
+            connectivityChecks.Should().HaveCount(2, "both journal and snapshot connectivity checks should be registered");
+            connectivityChecks.Should().OnlyContain(e => e.Value.Status == HealthStatus.Healthy);
+
+            foreach (var check in connectivityChecks)
+            {
+                Output?.WriteLine($"{check.Key}: {check.Value.Status} - {check.Value.Description}");
+            }
+        }
+
+        [Fact]
+        public async Task Connectivity_checks_should_have_correct_tags()
+        {
+            // Arrange
+            var healthCheckService = Host.Services.GetRequiredService<HealthCheckService>();
+
+            // Act
+            var result = await healthCheckService.CheckHealthAsync();
+
+            // Assert
+            var journalCheck = result.Entries.First(e => e.Key.Contains("Journal") && e.Key.Contains("Connectivity"));
+            journalCheck.Value.Tags.Should().Contain("akka");
+            journalCheck.Value.Tags.Should().Contain("persistence");
+            journalCheck.Value.Tags.Should().Contain("azure");
+            journalCheck.Value.Tags.Should().Contain("journal");
+            journalCheck.Value.Tags.Should().Contain("connectivity");
+
+            var snapshotCheck = result.Entries.First(e => e.Key.Contains("SnapshotStore") && e.Key.Contains("Connectivity"));
+            snapshotCheck.Value.Tags.Should().Contain("akka");
+            snapshotCheck.Value.Tags.Should().Contain("persistence");
+            snapshotCheck.Value.Tags.Should().Contain("azure");
+            snapshotCheck.Value.Tags.Should().Contain("snapshot-store");
+            snapshotCheck.Value.Tags.Should().Contain("connectivity");
+        }
+    }
+
+    /// <summary>
+    /// Tests for connectivity checks with invalid connections.
+    /// These tests verify that health checks properly detect connection failures.
+    /// </summary>
+    public class AzureConnectivityCheckInvalidConnectionSpec : Akka.Hosting.TestKit.TestKit
+    {
+        public AzureConnectivityCheckInvalidConnectionSpec(ITestOutputHelper output)
+            : base(nameof(AzureConnectivityCheckInvalidConnectionSpec), output)
+        {
+        }
+
+        protected override void ConfigureServices(HostBuilderContext context, IServiceCollection services)
+        {
+            base.ConfigureServices(context, services);
+            services.AddHealthChecks();
+        }
+
+        protected override void ConfigureAkka(AkkaConfigurationBuilder builder, IServiceProvider provider)
+        {
+            // Use an invalid connection string that will fail connectivity checks
+            var invalidConnectionString = "DefaultEndpointsProtocol=https;AccountName=invalidaccount;AccountKey=aW52YWxpZGtleQ==;EndpointSuffix=core.windows.net";
+
+            var journalOptions = new AzureTableStorageJournalOptions(isDefault: true)
+            {
+                ConnectionString = invalidConnectionString,
+                TableName = "connectivitytest",
+                AutoInitialize = false // Don't auto-initialize with invalid connection
+            };
+
+            var snapshotOptions = new AzureBlobSnapshotOptions(isDefault: true)
+            {
+                ConnectionString = invalidConnectionString,
+                ContainerName = "connectivity-test-snapshots",
+                AutoInitialize = false // Don't auto-initialize with invalid connection
+            };
+
+            builder
+                .WithAzureTableJournal(journalOptions, journal =>
+                {
+                    journal.WithConnectivityCheck(journalOptions, HealthStatus.Degraded);
+                })
+                .WithAzureBlobsSnapshotStore(snapshotOptions, snapshot =>
+                {
+                    snapshot.WithConnectivityCheck(snapshotOptions, HealthStatus.Degraded);
+                });
+        }
+
+        [Fact]
+        public async Task Journal_connectivity_check_should_report_unhealthy_with_invalid_connection()
+        {
+            // Arrange
+            var healthCheckService = Host.Services.GetRequiredService<HealthCheckService>();
+
+            // Act
+            var result = await healthCheckService.CheckHealthAsync();
+
+            // Assert
+            var journalCheck = result.Entries.First(e => e.Key.Contains("Journal") && e.Key.Contains("Connectivity"));
+            journalCheck.Value.Status.Should().Be(HealthStatus.Unhealthy, "because the connection is invalid");
+            journalCheck.Value.Description.Should().Contain("connection failed");
+            journalCheck.Value.Exception.Should().NotBeNull("because the connection should have failed with an exception");
+
+            Output?.WriteLine($"Journal connectivity check: {journalCheck.Key}");
+            Output?.WriteLine($"Status: {journalCheck.Value.Status}");
+            Output?.WriteLine($"Description: {journalCheck.Value.Description}");
+            Output?.WriteLine($"Exception: {journalCheck.Value.Exception?.Message}");
+        }
+
+        [Fact]
+        public async Task Snapshot_connectivity_check_should_report_unhealthy_with_invalid_connection()
+        {
+            // Arrange
+            var healthCheckService = Host.Services.GetRequiredService<HealthCheckService>();
+
+            // Act
+            var result = await healthCheckService.CheckHealthAsync();
+
+            // Assert
+            var snapshotCheck = result.Entries.First(e => e.Key.Contains("SnapshotStore") && e.Key.Contains("Connectivity"));
+            snapshotCheck.Value.Status.Should().Be(HealthStatus.Unhealthy, "because the connection is invalid");
+            snapshotCheck.Value.Description.Should().Contain("connection failed");
+            snapshotCheck.Value.Exception.Should().NotBeNull("because the connection should have failed with an exception");
+
+            Output?.WriteLine($"Snapshot connectivity check: {snapshotCheck.Key}");
+            Output?.WriteLine($"Status: {snapshotCheck.Value.Status}");
+            Output?.WriteLine($"Description: {snapshotCheck.Value.Description}");
+            Output?.WriteLine($"Exception: {snapshotCheck.Value.Exception?.Message}");
+        }
+
+        [Fact]
+        public async Task Overall_health_status_should_be_unhealthy_when_connectivity_fails()
+        {
+            // Arrange
+            var healthCheckService = Host.Services.GetRequiredService<HealthCheckService>();
+
+            // Act
+            var result = await healthCheckService.CheckHealthAsync();
+
+            // Assert
+            result.Status.Should().Be(HealthStatus.Unhealthy,
+                "because at least one health check is unhealthy");
+
+            var connectivityChecks = result.Entries
+                .Where(e => e.Key.Contains("Connectivity"))
+                .ToList();
+
+            connectivityChecks.Should().HaveCount(2);
+            connectivityChecks.Should().OnlyContain(e => e.Value.Status == HealthStatus.Unhealthy);
+
+            foreach (var check in connectivityChecks)
+            {
+                Output?.WriteLine($"{check.Key}: {check.Value.Status} - {check.Value.Description}");
+            }
+        }
+    }
+}

--- a/src/Akka.Persistence.Azure.Tests/Hosting/AzureConnectivityCheckSpec.cs
+++ b/src/Akka.Persistence.Azure.Tests/Hosting/AzureConnectivityCheckSpec.cs
@@ -59,11 +59,13 @@ namespace Akka.Persistence.Azure.Tests.Hosting
             builder
                 .WithAzureTableJournal(journalOptions, journal =>
                 {
-                    journal.WithConnectivityCheck(journalOptions);
+                    // Using the new simplified API from Akka.Hosting 1.5.55.1
+                    journal.WithConnectivityCheck();
                 })
                 .WithAzureBlobsSnapshotStore(snapshotOptions, snapshot =>
                 {
-                    snapshot.WithConnectivityCheck(snapshotOptions);
+                    // Using the new simplified API from Akka.Hosting 1.5.55.1
+                    snapshot.WithConnectivityCheck();
                 });
         }
 
@@ -219,11 +221,13 @@ namespace Akka.Persistence.Azure.Tests.Hosting
             builder
                 .WithAzureTableJournal(journalOptions, journal =>
                 {
-                    journal.WithConnectivityCheck(journalOptions, HealthStatus.Degraded);
+                    // Using the new simplified API from Akka.Hosting 1.5.55.1
+                    journal.WithConnectivityCheck(HealthStatus.Degraded);
                 })
                 .WithAzureBlobsSnapshotStore(snapshotOptions, snapshot =>
                 {
-                    snapshot.WithConnectivityCheck(snapshotOptions, HealthStatus.Degraded);
+                    // Using the new simplified API from Akka.Hosting 1.5.55.1
+                    snapshot.WithConnectivityCheck(HealthStatus.Degraded);
                 });
         }
 

--- a/src/Akka.Persistence.Azure.Tests/Hosting/AzurePersistenceHealthCheckSpec.cs
+++ b/src/Akka.Persistence.Azure.Tests/Hosting/AzurePersistenceHealthCheckSpec.cs
@@ -47,7 +47,7 @@ namespace Akka.Persistence.Azure.Tests.Hosting
 
             // Assert
             result.Status.Should().Be(HealthStatus.Healthy);
-            result.Entries.Keys.Should().Contain("Akka.Persistence.Journal.azure-table");
+            result.Entries.Keys.Should().Contain("akka.persistence.journal.azure-table");
         }
 
         [Fact]
@@ -59,7 +59,7 @@ namespace Akka.Persistence.Azure.Tests.Hosting
 
             // Assert
             result.Status.Should().Be(HealthStatus.Healthy);
-            result.Entries.Keys.Should().Contain("Akka.Persistence.SnapshotStore.azure-blob-store");
+            result.Entries.Keys.Should().Contain("akka.persistence.snapshot-store.azure-blob-store");
         }
 
         [Fact]
@@ -71,8 +71,8 @@ namespace Akka.Persistence.Azure.Tests.Hosting
 
             // Assert
             result.Status.Should().Be(HealthStatus.Healthy);
-            result.Entries.Keys.Should().Contain("Akka.Persistence.Journal.azure-table");
-            result.Entries.Keys.Should().Contain("Akka.Persistence.SnapshotStore.azure-blob-store");
+            result.Entries.Keys.Should().Contain("akka.persistence.journal.azure-table");
+            result.Entries.Keys.Should().Contain("akka.persistence.snapshot-store.azure-blob-store");
         }
 
         [Fact]
@@ -85,8 +85,8 @@ namespace Akka.Persistence.Azure.Tests.Hosting
             // Assert
             // Health checks should be registered and report as healthy (degraded status is for failures)
             result.Status.Should().Be(HealthStatus.Healthy);
-            result.Entries.Keys.Should().Contain("Akka.Persistence.Journal.azure-table");
-            result.Entries.Keys.Should().Contain("Akka.Persistence.SnapshotStore.azure-blob-store");
+            result.Entries.Keys.Should().Contain("akka.persistence.journal.azure-table");
+            result.Entries.Keys.Should().Contain("akka.persistence.snapshot-store.azure-blob-store");
         }
 
         [Fact]
@@ -108,16 +108,16 @@ namespace Akka.Persistence.Azure.Tests.Hosting
 
             // Assert
             result.Status.Should().Be(HealthStatus.Healthy);
-            result.Entries.Keys.Should().Contain("Akka.Persistence.Journal.azure-table");
-            result.Entries.Keys.Should().Contain("Akka.Persistence.SnapshotStore.azure-blob-store");
+            result.Entries.Keys.Should().Contain("akka.persistence.journal.azure-table");
+            result.Entries.Keys.Should().Contain("akka.persistence.snapshot-store.azure-blob-store");
 
             // Verify individual entries are healthy
-            result.Entries["Akka.Persistence.Journal.azure-table"].Status.Should().Be(HealthStatus.Healthy);
-            result.Entries["Akka.Persistence.SnapshotStore.azure-blob-store"].Status.Should().Be(HealthStatus.Healthy);
+            result.Entries["akka.persistence.journal.azure-table"].Status.Should().Be(HealthStatus.Healthy);
+            result.Entries["akka.persistence.snapshot-store.azure-blob-store"].Status.Should().Be(HealthStatus.Healthy);
 
             // Verify data and descriptions exist
-            result.Entries["Akka.Persistence.Journal.azure-table"].Data.Should().NotBeNull();
-            result.Entries["Akka.Persistence.SnapshotStore.azure-blob-store"].Data.Should().NotBeNull();
+            result.Entries["akka.persistence.journal.azure-table"].Data.Should().NotBeNull();
+            result.Entries["akka.persistence.snapshot-store.azure-blob-store"].Data.Should().NotBeNull();
         }
 
         public sealed class MyPersistenceActor : ReceivePersistentActor

--- a/src/Akka.Persistence.Azure/Journal/AzureTableStorageJournalSettings.cs
+++ b/src/Akka.Persistence.Azure/Journal/AzureTableStorageJournalSettings.cs
@@ -177,6 +177,38 @@ namespace Akka.Persistence.Azure.Journal
         /// </summary>
         public Func<TableServiceClient>? TableServiceClientFactory { get; }
 
+        /// <summary>
+        ///     Creates a TableServiceClient using the configured connection settings.
+        ///     Priority order: TableServiceClientFactory > ServiceUri + AzureCredential > ConnectionString
+        /// </summary>
+        /// <returns>A configured TableServiceClient instance</returns>
+        /// <exception cref="ConfigurationException">Thrown when no valid connection method is configured</exception>
+        public TableServiceClient CreateTableServiceClient()
+        {
+            if (TableServiceClientFactory != null)
+            {
+                return TableServiceClientFactory.Invoke();
+            }
+
+            // Use TokenCredential if both ServiceUri and TokenCredential are populated
+            if (ServiceUri != null && AzureCredential != null)
+            {
+                return new TableServiceClient(
+                    endpoint: ServiceUri,
+                    tokenCredential: AzureCredential,
+                    options: TableClientOptions);
+            }
+
+            if (!string.IsNullOrWhiteSpace(ConnectionString))
+            {
+                return new TableServiceClient(connectionString: ConnectionString);
+            }
+
+            throw new ConfigurationException(
+                "No connection method configured. ConnectionString, AzureCredential, or " +
+                "TableServiceClientFactory must be specified.");
+        }
+
         public AzureTableStorageJournalSettings WithConnectionString(string connectionString)
             => Copy(connectionString: connectionString);
         public AzureTableStorageJournalSettings WithTableName(string tableName)

--- a/src/Akka.Persistence.Azure/Snapshot/AzureBlobSnapshotStoreSettings.cs
+++ b/src/Akka.Persistence.Azure/Snapshot/AzureBlobSnapshotStoreSettings.cs
@@ -248,6 +248,37 @@ namespace Akka.Persistence.Azure.Snapshot
         /// </summary>
         public Func<BlobServiceClient>? BlobServiceClientFactory { get; }
 
+        /// <summary>
+        ///     Creates a BlobServiceClient using the configured connection settings.
+        ///     Priority order: BlobServiceClientFactory > ServiceUri + AzureCredential > ConnectionString
+        /// </summary>
+        /// <returns>A configured BlobServiceClient instance</returns>
+        /// <exception cref="ConfigurationException">Thrown when no valid connection method is configured</exception>
+        public BlobServiceClient CreateBlobServiceClient()
+        {
+            if (BlobServiceClientFactory != null)
+            {
+                return BlobServiceClientFactory.Invoke();
+            }
+
+            if (ServiceUri != null && AzureCredential != null)
+            {
+                return new BlobServiceClient(
+                    serviceUri: ServiceUri,
+                    credential: AzureCredential,
+                    options: BlobClientOptions);
+            }
+
+            if (!string.IsNullOrWhiteSpace(ConnectionString))
+            {
+                return new BlobServiceClient(connectionString: ConnectionString);
+            }
+
+            throw new ConfigurationException(
+                "No connection method configured. ConnectionString, AzureCredential, or BlobServiceClient " +
+                "must be specified.");
+        }
+
         public AzureBlobSnapshotStoreSettings WithConnectionString(string connectionString)
             => Copy(connectionString: connectionString);
         public AzureBlobSnapshotStoreSettings WithContainerName(string containerName)

--- a/src/Directory.Generated.props
+++ b/src/Directory.Generated.props
@@ -1,14 +1,44 @@
 <Project>
   <PropertyGroup>
-    <VersionPrefix>1.5.51.1</VersionPrefix>
-    <PackageReleaseNotes>* [Update Akka.Hosting v1.5.51.1](https://github.com/akkadotnet/Akka.Hosting/releases/tag/1.5.51.1)
-* [Fix Akka.Persistence.Azure.Hosting health checks and adopt unified API](https://github.com/petabridge/Akka.Persistence.Azure/pull/531)
+    <VersionPrefix>1.5.55</VersionPrefix>
+    <PackageReleaseNotes>* [Update Akka.NET v1.5.55](https://github.com/akkadotnet/akka.net/releases/tag/1.5.55)
+* [Update Akka.Hosting v1.5.55](https://github.com/akkadotnet/Akka.Hosting/releases/tag/1.5.55)
+* [Add connectivity health checks for Azure persistence backends](https://github.com/petabridge/Akka.Persistence.Azure/pull/TBD)
 
-This patch release fixes critical issues in the Akka.Persistence.Azure.Hosting extension methods:
+This release adds proactive connectivity health checks for Azure persistence backends, implementing the feature requested in [Akka.Hosting#678](https://github.com/akkadotnet/Akka.Hosting/issues/678).
 
-- Health checks are now properly registered for both journal and snapshot store
-- Snapshot store health check support added via `Action&lt;AkkaPersistenceSnapshotBuilder&gt;` parameters
-- Migrated from manual HOCON manipulation to the unified Akka.Hosting API (`.WithJournal()` and `.WithSnapshot()`)
-- All changes are backward compatible with no breaking changes</PackageReleaseNotes>
+**New Features:**
+
+Connectivity checks are now available for both Azure Table Storage journal and Azure Blob Storage snapshot store. These are opt-in health checks that proactively verify backend connectivity regardless of recent operation activity, helping detect database outages during idle periods.
+
+**Usage Example:**
+
+```csharp
+var journalOptions = new AzureTableStorageJournalOptions(isDefault: true)
+{
+    ConnectionString = connectionString,
+    TableName = "akkajournal",
+    AutoInitialize = true
+};
+
+var snapshotOptions = new AzureBlobSnapshotOptions(isDefault: true)
+{
+    ConnectionString = connectionString,
+    ContainerName = "akka-snapshots",
+    AutoInitialize = true
+};
+
+builder
+    .WithAzureTableJournal(journalOptions, journal =&gt;
+    {
+        journal.WithConnectivityCheck(journalOptions);
+    })
+    .WithAzureBlobsSnapshotStore(snapshotOptions, snapshot =&gt;
+    {
+        snapshot.WithConnectivityCheck(snapshotOptions);
+    });
+```
+
+The connectivity checks support all Azure SDK connection methods (connection string, ServiceUri + TokenCredential, and factory methods) and include proper tagging for filtering in health check endpoints.</PackageReleaseNotes>
   </PropertyGroup>
 </Project>

--- a/src/Directory.Generated.props
+++ b/src/Directory.Generated.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <VersionPrefix>1.5.55</VersionPrefix>
     <PackageReleaseNotes>* [Update Akka.NET v1.5.55](https://github.com/akkadotnet/akka.net/releases/tag/1.5.55)
-* [Update Akka.Hosting v1.5.55](https://github.com/akkadotnet/Akka.Hosting/releases/tag/1.5.55)
+* [Update Akka.Hosting v1.5.55.1](https://github.com/akkadotnet/Akka.Hosting/releases/tag/1.5.55.1)
 * [Add connectivity health checks for Azure persistence backends](https://github.com/petabridge/Akka.Persistence.Azure/pull/TBD)
 
 This release adds proactive connectivity health checks for Azure persistence backends, implementing the feature requested in [Akka.Hosting#678](https://github.com/akkadotnet/Akka.Hosting/issues/678).
@@ -10,6 +10,10 @@ This release adds proactive connectivity health checks for Azure persistence bac
 **New Features:**
 
 Connectivity checks are now available for both Azure Table Storage journal and Azure Blob Storage snapshot store. These are opt-in health checks that proactively verify backend connectivity regardless of recent operation activity, helping detect database outages during idle periods.
+
+**Improved API:**
+
+With Akka.Hosting 1.5.55.1, the connectivity check API has been simplified. Options are now automatically accessed from the builder, eliminating redundant parameter passing.
 
 **Usage Example:**
 
@@ -31,14 +35,18 @@ var snapshotOptions = new AzureBlobSnapshotOptions(isDefault: true)
 builder
     .WithAzureTableJournal(journalOptions, journal =&gt;
     {
-        journal.WithConnectivityCheck(journalOptions);
+        journal.WithConnectivityCheck(); // Simplified API!
     })
     .WithAzureBlobsSnapshotStore(snapshotOptions, snapshot =&gt;
     {
-        snapshot.WithConnectivityCheck(snapshotOptions);
+        snapshot.WithConnectivityCheck(); // Simplified API!
     });
 ```
 
-The connectivity checks support all Azure SDK connection methods (connection string, ServiceUri + TokenCredential, and factory methods) and include proper tagging for filtering in health check endpoints.</PackageReleaseNotes>
+The connectivity checks support all Azure SDK connection methods (connection string, ServiceUri + TokenCredential, and factory methods) and include proper tagging for filtering in health check endpoints.
+
+**Backward Compatibility:**
+
+The old API signature (passing options explicitly) is still supported for backward compatibility with older versions of Akka.Hosting.</PackageReleaseNotes>
   </PropertyGroup>
 </Project>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <AkkaVersion>1.5.55</AkkaVersion>
-    <AkkaHostingVersion>1.5.55</AkkaHostingVersion>
+    <AkkaHostingVersion>1.5.55.1</AkkaHostingVersion>
   </PropertyGroup>
   <!-- App dependencies -->
   <ItemGroup>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -1,8 +1,8 @@
 <Project>
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-    <AkkaVersion>1.5.53</AkkaVersion>
-    <AkkaHostingVersion>1.5.53</AkkaHostingVersion>
+    <AkkaVersion>1.5.55</AkkaVersion>
+    <AkkaHostingVersion>1.5.55</AkkaHostingVersion>
   </PropertyGroup>
   <!-- App dependencies -->
   <ItemGroup>


### PR DESCRIPTION
## Summary

This PR adds proactive connectivity health checks for Azure persistence backends, implementing the feature requested in https://github.com/akkadotnet/Akka.Hosting/issues/678.

## Changes

### New Features

- **Connectivity Health Checks**: Proactive health checks that verify Azure backend connectivity regardless of recent operation activity
  - `AzureTableJournalConnectivityCheck` for Azure Table Storage journal
  - `AzureBlobSnapshotStoreConnectivityCheck` for Azure Blob Storage snapshot store
  
- **Simplified API** (requires Akka.Hosting 1.5.55.1+):
  ```csharp
  journal.WithConnectivityCheck(); // Options accessed from builder automatically
  ```

- **Backward Compatibility**: Original API with explicit options parameter still supported

### Dependencies

- Updated Akka.NET from 1.5.53 to 1.5.55
- Updated Akka.Hosting from 1.5.53 to 1.5.55.1

### Documentation

- Comprehensive README.md documentation covering both standard and connectivity health checks
- Detailed usage examples for all connection methods (connection strings, ServiceUri + TokenCredential, factory methods)
- Updated RELEASE_NOTES.md with API improvement details

### Testing

- 9 comprehensive tests covering valid and invalid connection scenarios
- All tests passing ✅

## API Example

**Before (Akka.Hosting 1.5.55):**
```csharp
journal.WithConnectivityCheck(journalOptions); // Had to pass options explicitly
```

**After (Akka.Hosting 1.5.55.1):**
```csharp
journal.WithConnectivityCheck(); // Options accessed automatically from builder
```

Both API styles continue to work for backward compatibility.

## Related Issues

- Implements https://github.com/akkadotnet/Akka.Hosting/issues/678
- Depends on https://github.com/akkadotnet/Akka.Hosting/pull/691 (merged and released in Akka.Hosting 1.5.55.1)