### PR TITLE
Fix Health Check Permission Requirements

### DIFF
--- a/src/Akka.Persistence.Azure.API.Tests/verify/ApiSpecs.ApproveHosting.DotNet.verified.txt
+++ b/src/Akka.Persistence.Azure.API.Tests/verify/ApiSpecs.ApproveHosting.DotNet.verified.txt
@@ -33,7 +33,7 @@ namespace Akka.Persistence.Azure.Hosting
     {
         public AzureBlobSnapshotStoreConnectivityCheck(string connectionString, System.Uri serviceUri, Azure.Core.TokenCredential azureCredential, Azure.Storage.Blobs.BlobClientOptions blobClientOptions, [System.Runtime.CompilerServices.NullableAttribute(new byte[] {
                 2,
-                1})] System.Func<Azure.Storage.Blobs.BlobServiceClient> blobServiceClientFactory, [System.Runtime.CompilerServices.NullableAttribute(1)] string snapshotStoreId) { }
+                1})] System.Func<Azure.Storage.Blobs.BlobServiceClient> blobServiceClientFactory, [System.Runtime.CompilerServices.NullableAttribute(1)] string containerName, [System.Runtime.CompilerServices.NullableAttribute(1)] string snapshotStoreId) { }
         public System.Threading.Tasks.Task<Microsoft.Extensions.Diagnostics.HealthChecks.HealthCheckResult> CheckHealthAsync(Akka.Hosting.AkkaHealthCheckContext context, System.Threading.CancellationToken cancellationToken = null) { }
     }
     [System.Runtime.CompilerServices.NullableAttribute(0)]
@@ -110,7 +110,7 @@ namespace Akka.Persistence.Azure.Hosting
     {
         public AzureTableJournalConnectivityCheck(string connectionString, System.Uri serviceUri, Azure.Core.TokenCredential azureCredential, Azure.Data.Tables.TableClientOptions tableClientOptions, [System.Runtime.CompilerServices.NullableAttribute(new byte[] {
                 2,
-                1})] System.Func<Azure.Data.Tables.TableServiceClient> tableServiceClientFactory, [System.Runtime.CompilerServices.NullableAttribute(1)] string journalId) { }
+                1})] System.Func<Azure.Data.Tables.TableServiceClient> tableServiceClientFactory, [System.Runtime.CompilerServices.NullableAttribute(1)] string tableName, [System.Runtime.CompilerServices.NullableAttribute(1)] string journalId) { }
         public System.Threading.Tasks.Task<Microsoft.Extensions.Diagnostics.HealthChecks.HealthCheckResult> CheckHealthAsync(Akka.Hosting.AkkaHealthCheckContext context, System.Threading.CancellationToken cancellationToken = null) { }
     }
     [System.Runtime.CompilerServices.NullableAttribute(0)]

--- a/src/Akka.Persistence.Azure.Hosting/AzureBlobSnapshotStoreConnectivityCheck.cs
+++ b/src/Akka.Persistence.Azure.Hosting/AzureBlobSnapshotStoreConnectivityCheck.cs
@@ -21,7 +21,7 @@ namespace Akka.Persistence.Azure.Hosting
     /// </summary>
     public sealed class AzureBlobSnapshotStoreConnectivityCheck : IAkkaHealthCheck
     {
-        private readonly BlobServiceClient _blobServiceClient;
+        private readonly BlobContainerClient _blobContainerClient;
         private readonly string _snapshotStoreId;
 
         public AzureBlobSnapshotStoreConnectivityCheck(
@@ -30,26 +30,31 @@ namespace Akka.Persistence.Azure.Hosting
             TokenCredential? azureCredential,
             BlobClientOptions? blobClientOptions,
             Func<BlobServiceClient>? blobServiceClientFactory,
+            string containerName,
             string snapshotStoreId)
         {
             _snapshotStoreId = snapshotStoreId ?? throw new ArgumentNullException(nameof(snapshotStoreId));
 
+            if (string.IsNullOrWhiteSpace(containerName))
+                throw new ArgumentNullException(nameof(containerName));
+
             // Create client once and cache it - matches the pattern used in AzureBlobSnapshotStore
             // Priority: Factory > ServiceUri + Credential > ConnectionString
+            BlobServiceClient blobServiceClient;
             if (blobServiceClientFactory != null)
             {
-                _blobServiceClient = blobServiceClientFactory();
+                blobServiceClient = blobServiceClientFactory();
             }
             else if (serviceUri != null && azureCredential != null)
             {
-                _blobServiceClient = new BlobServiceClient(
+                blobServiceClient = new BlobServiceClient(
                     serviceUri: serviceUri,
                     credential: azureCredential,
                     options: blobClientOptions);
             }
             else if (!string.IsNullOrWhiteSpace(connectionString))
             {
-                _blobServiceClient = new BlobServiceClient(connectionString);
+                blobServiceClient = new BlobServiceClient(connectionString);
             }
             else
             {
@@ -57,6 +62,9 @@ namespace Akka.Persistence.Azure.Hosting
                     "At least one of ConnectionString, ServiceUri + AzureCredential, or BlobServiceClientFactory must be provided",
                     nameof(connectionString));
             }
+
+            // Get the specific container client - this is what the snapshot store uses for all operations
+            _blobContainerClient = blobServiceClient.GetBlobContainerClient(containerName);
         }
 
         public async Task<HealthCheckResult> CheckHealthAsync(
@@ -65,9 +73,12 @@ namespace Akka.Persistence.Azure.Hosting
         {
             try
             {
-                // Use the cached client instead of creating a new one on each check
-                // This prevents authentication storms and rate limiting issues
-                await _blobServiceClient.GetPropertiesAsync(cancellationToken);
+                // Use the same check as the snapshot store's InitCloudStorage() method
+                // Check if the container exists - this verifies connectivity to Azure Blob Storage
+                // This uses container-level permissions (same as snapshot store initialization) rather than
+                // service-level properties permissions
+                // Successfully executing this check proves connectivity, regardless of whether the container exists
+                await _blobContainerClient.ExistsAsync(cancellationToken);
 
                 return HealthCheckResult.Healthy($"Azure Blob snapshot store '{_snapshotStoreId}' connection successful");
             }

--- a/src/Akka.Persistence.Azure.Hosting/AzureConnectivityCheckExtensions.cs
+++ b/src/Akka.Persistence.Azure.Hosting/AzureConnectivityCheckExtensions.cs
@@ -84,6 +84,7 @@ namespace Akka.Persistence.Azure.Hosting
                     journalOptions.AzureCredential,
                     journalOptions.TableClientOptions,
                     journalOptions.TableServiceClientFactory,
+                    journalOptions.TableName ?? "AkkaPersistenceDefaultTable",
                     journalOptions.Identifier),
                 unHealthyStatus,
                 tags ?? new[] { "akka", "persistence", "azure", "journal", "connectivity" });
@@ -159,6 +160,7 @@ namespace Akka.Persistence.Azure.Hosting
                     snapshotOptions.AzureCredential,
                     snapshotOptions.BlobClientOptions,
                     snapshotOptions.BlobServiceClientFactory,
+                    snapshotOptions.ContainerName ?? "akka-persistence-default-container",
                     snapshotOptions.Identifier),
                 unHealthyStatus,
                 tags ?? new[] { "akka", "persistence", "azure", "snapshot-store", "connectivity" });

--- a/src/Akka.Persistence.Azure.Hosting/AzureTableJournalConnectivityCheck.cs
+++ b/src/Akka.Persistence.Azure.Hosting/AzureTableJournalConnectivityCheck.cs
@@ -22,6 +22,7 @@ namespace Akka.Persistence.Azure.Hosting
     public sealed class AzureTableJournalConnectivityCheck : IAkkaHealthCheck
     {
         private readonly TableServiceClient _tableServiceClient;
+        private readonly string _tableName;
         private readonly string _journalId;
 
         public AzureTableJournalConnectivityCheck(
@@ -30,9 +31,11 @@ namespace Akka.Persistence.Azure.Hosting
             TokenCredential? azureCredential,
             TableClientOptions? tableClientOptions,
             Func<TableServiceClient>? tableServiceClientFactory,
+            string tableName,
             string journalId)
         {
             _journalId = journalId ?? throw new ArgumentNullException(nameof(journalId));
+            _tableName = tableName ?? throw new ArgumentNullException(nameof(tableName));
 
             // Create client once and cache it - matches the pattern used in AzureTableStorageJournal
             // Priority: Factory > ServiceUri + Credential > ConnectionString
@@ -65,9 +68,19 @@ namespace Akka.Persistence.Azure.Hosting
         {
             try
             {
-                // Use the cached client instead of creating a new one on each check
-                // This prevents authentication storms and rate limiting issues
-                await _tableServiceClient.GetPropertiesAsync(cancellationToken);
+                // Use the same check as the journal's IsTableExist() method
+                // Query for the table name - this verifies connectivity to Azure Table Storage
+                // This uses table list permissions (same as journal initialization) rather than
+                // service-level properties permissions
+                // Successfully executing this query proves connectivity, regardless of whether the table exists
+                var query = _tableServiceClient.QueryAsync(
+                    t => t.Name == _tableName,
+                    cancellationToken: cancellationToken);
+
+                // Execute the query to verify connectivity
+                // Use await using to ensure the enumerator is properly disposed
+                await using var enumerator = query.GetAsyncEnumerator(cancellationToken);
+                await enumerator.MoveNextAsync(); // We only need to verify the query executes successfully
 
                 return HealthCheckResult.Healthy($"Azure Table journal '{_journalId}' connection successful");
             }


### PR DESCRIPTION
## Problem
Health checks were using `GetPropertiesAsync()` which requires service-level permissions that are separate from the permissions needed by the journal and snapshot store. Users reported authentication failures because their Azure credentials didn't have these additional permissions.

## Solution
Changed health checks to use the same operations as the journal and snapshot store initialization:

- **Table Journal**: Now uses `TableServiceClient.QueryAsync(t => t.Name == tableName)` - same as journal's `IsTableExist()` method
- **Blob Snapshot Store**: Now uses `BlobContainerClient.ExistsAsync()` - same as snapshot store's `InitCloudStorage()` method

## Changes

### AzureTableJournalConnectivityCheck
- Changed from `TableServiceClient.GetPropertiesAsync()` to `TableServiceClient.QueryAsync()`
- Added `tableName` parameter to constructor
- Added explicit async enumerator disposal with `await using`

### AzureBlobSnapshotStoreConnectivityCheck
- Changed from `BlobServiceClient.GetPropertiesAsync()` to `BlobContainerClient.ExistsAsync()`
- Added `containerName` parameter to constructor
- Uses container client instead of service client

### AzureConnectivityCheckExtensions
- Updated to pass `TableName` and `ContainerName` to health check constructors

## Benefits
- Health checks now require only the same permissions as journal/snapshot store operations
- No additional Azure role assignments needed
- Works whether table/container exists or not (handles auto-initialize scenarios)
- All existing tests pass

## Testing
All 6 existing connectivity check tests pass, including:
- Valid connection scenarios
- Invalid connection scenarios
- Tag validation
- Status message verification
