### PR TITLE
Bump Akka.NET to 1.5.60

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -1,8 +1,8 @@
 <Project>
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-    <AkkaVersion>1.5.59</AkkaVersion>
-    <AkkaHostingVersion>1.5.59</AkkaHostingVersion>
+    <AkkaVersion>1.5.60</AkkaVersion>
+    <AkkaHostingVersion>1.5.60</AkkaHostingVersion>
   </PropertyGroup>
   <!-- App dependencies -->
   <ItemGroup>
@@ -20,7 +20,7 @@
   <!-- Test dependencies -->
   <ItemGroup>
     <PackageVersion Include="Akka.Hosting.TestKit" Version="$(AkkaHostingVersion)" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
     <PackageVersion Include="Akka.Cluster.Sharding" Version="$(AkkaVersion)" />
     <PackageVersion Include="NBench" Version="2.0.1" />
     <PackageVersion Include="Docker.DotNet" Version="3.125.15" />


### PR DESCRIPTION
Bumps AkkaVersion and AkkaHostingVersion to 1.5.60.

Also updates Microsoft.Extensions.Hosting to 8.0.0 to resolve dependency compatibility issues with the new Akka.Hosting.TestKit version.